### PR TITLE
Hytera updates

### DIFF
--- a/doc/reveng/hytera/extract.py
+++ b/doc/reveng/hytera/extract.py
@@ -157,17 +157,9 @@ elif "download_contacts" == args.command:
   assert len(contactSlots) == tableElements
 
   # Now traverse
-  visitedIndexes = []
-  while True:
-    currentSlot = next(filter(lambda s: s[0] == currentIndex, contactSlots))
-    link = currentSlot[7]
+  for currentSlot in contactSlots:
     type = currentSlot[2]
     isRef = currentSlot[3]
-
-    if currentIndex in visitedIndexes:
-      break
-
-    visitedIndexes.append(currentIndex)
 
     typeName = "Unknown"
     if type == 0:
@@ -184,7 +176,5 @@ elif "download_contacts" == args.command:
 
     if type != 0x11:
       table.add_row(currentSlot)
-
-    currentIndex = link
 
   print(table)

--- a/doc/reveng/hytera/pd785g/codeplug-format.md
+++ b/doc/reveng/hytera/pd785g/codeplug-format.md
@@ -91,12 +91,24 @@ interpreted as a 32-bit unsigned LE integer yields `450712500`.
 ```c
 typedef uint32_t freq_t // 32-bit fixed point frequency
 
+#define FLAG_LOW_POWER (1 << 4)
+#define FLAGS2_SLOT_2 (1 << 0)
+#define FLAGS2_VOX (1 << 6)
+
 typedef struct
 {
-    ...
+    char name[32];
+    uint8_t unk4;
+    uint8_t flags;
+    uint16_t unkN1;
     freq_t rx_freq;
     freq_t tx_freq;
-    ...
+    uint16_t unk0;
+    uint8_t unk1[3];
+    uint8_t colour_code;
+    uint16_t tx_contact_idx;
+    uint8_t unk2[6];
+    uint8_t flags2;
 } digital_chan_t;
 
 ```


### PR DESCRIPTION
It looks like all the work around `index` and `link` in tx_contacts is completely wrong.  I downloaded the CP from my X1p and had a look at the graph generated by the contact list, see attachment.  Wow.  That completely blows my theory about how the list traversal works out of the water.

I've also been looking at channel format and it looks like channels index the TX contact by offset into the contact table, rather than using the `index` field.   So these fields are currently a mystery.

[out.pdf](https://github.com/hmatuschek/qdmr/files/6192945/out.pdf)
