### PR TITLE
Further hytera work

### DIFF
--- a/doc/reveng/hytera/cps.py
+++ b/doc/reveng/hytera/cps.py
@@ -1,97 +1,220 @@
 #!/usr/bin/env python3
-
-import sys
-import binascii
-import itertools
-import usb.core
-import usb.util
-import math
 import struct
-from radio import CPSRadio
-from prettytable import PrettyTable
-from typing import List, Tuple
 import argparse
+from prettytable import PrettyTable  # type: ignore
 import packet
+from radio import CPSRadio
+from typing import List
+from enum import Enum
 
-def read(radio : CPSRadio, startAddr : int, length : int) -> bytes:
-  read_chunk_sz = 0x100
-  end_address = startAddr + length
-  ret = bytes()
 
-  for addr in range(startAddr, end_address, read_chunk_sz):
-    length = read_chunk_sz if (addr + read_chunk_sz) < end_address else end_address - addr
+class DigitalContact:
+    """A class that represents a digitial channel."""
+    STRUCT_FMT = '<H32sBBHIIH'
 
-    resp = radio.xfer(packet.Packet.readCodeplug(addr, length))
+    class CALL_TYPE(Enum):
+        """Type of call that is made when this contact is called.
 
-    ret += resp._content._content._payload
+        If the contact type is IGNORE, the contact is ignored by the radio and
+        the CPS.
+        """
+        PRIVATE = 0
+        GROUP = 1
+        IGNORE = 0x11
 
-  return ret
+    def __init__(self, data: bytes) -> None:
+        fields = struct.unpack(DigitalContact.STRUCT_FMT, data)
+        self.idx = fields[0]
+        self.name = fields[1].decode('utf-8')
+        self.call_type = DigitalContact.CALL_TYPE(fields[2])
+        self.is_ref = bool(fields[3])
+        self.id = fields[5]
+        self.link = fields[7]
 
-def dump(args):
-  with CPSRadio(args.verbose) as radio:
-    data = read(radio, 0, 0x1fffff)
-    args.OUT_FILE.write(data)
+    @staticmethod
+    def size() -> int:
+        """Get the size of the contact structure."""
+        return struct.calcsize(DigitalContact.STRUCT_FMT)
 
-def dumpContacts(args):
-  with CPSRadio(args.verbose) as radio:
-    contactStructure = '<H32sBBHIIH'
-    tableElements = struct.unpack('<H', read(radio, 0x65b5c, 2))[0]
-    tableSize = tableElements * struct.calcsize(contactStructure)
-    contactTable = read(radio, 0x65b70, tableSize)
 
-    table = PrettyTable(['Index','Name', 'Type', 'Is referenced', 'pad1', 'id', 'unk1', 'link'])
-    contactSlots = []
+class DigitalChannel:
+    """Represents a digitial channel in the codeplug."""
+    # pylint: disable=too-many-instance-attributes
+    # This class will have many attributes since it represnts a
+    # digitial channel.
+    STRUCT_FMT = '<32sbbHIIbbbbbbHHHbbbbbbHbbHbbbbH10b'
 
-    # Build contact table.
-    for idx, name, type, is_ref, pad1, id, unk1, link in struct.iter_unpack(contactStructure, contactTable):
-      contactSlots.append([idx, name.decode('utf-8'), type, is_ref, pad1, id, unk1, link])
+    class PowerLevel(Enum):
+        """The default power level for the channel."""
+        HIGH = 0x0
+        LOW = 0x4
 
-    # Now traverse
-    for currentSlot in contactSlots:
-      type = currentSlot[2]
-      isRef = currentSlot[3]
+    class TxAdmit(Enum):
+        """The TX admit mode for the channel."""
+        ALWAYS = 0
+        CHANNEL = 1
+        COLOR_CODE = 2
 
-      typeName = "Unknown"
-      if type == 0:
-        typeName = 'Private Call'
-      elif type == 1:
-        typeName = 'Group Call'
+    def __init__(self, data: bytes) -> None:
+        fields = struct.unpack(DigitalChannel.STRUCT_FMT, data)
+        self.name = fields[0].decode('utf-8')
+        self.rx_only = bool(fields[2] & 0x01)
+        self.power = DigitalChannel.PowerLevel(fields[2] & 0x04)
+        self.rx_freq = fields[4]
+        self.tx_freq = fields[5]
+        self.tx_admit = DigitalChannel.TxAdmit(fields[6])
+        self.tx_timeout = fields[7]
+        self.tx_timeout_prealert = fields[8]
+        self.tx_timeout_rekey = fields[9]
+        self.tx_timeout_reset = fields[10]
+        self.colour_code = fields[11] & 0x0f
+        self.priority_interrupt_encode = fields[11] & 0x20
+        self.priority_interrupt_decode = fields[11] & 0x40
+        self.tx_contact_idx = fields[12]
+        self.rx_group_list_idx = fields[13]
+        self.emergency_system_idx = fields[14]
+        self.scan_list_idx = fields[15]
+        self.timeslot = fields[17] & 0x3
+        self.has_scan_idx = fields[17] & 0x10
+        self.vox = fields[17] & 0x20
+        self.option_board = fields[17] & 0x80
+        self.loc_revert_ch_idx = fields[21]
+        self.phone_system_idx = fields[24]
+        self.pseudo_trunk_tx = fields[25]
+        self.rrs_revert_ch = fields[29]
 
-      isRefString = "Unknown"
+    @staticmethod
+    def size() -> int:
+        """Return the size of the object."""
+        return struct.calcsize(DigitalChannel.STRUCT_FMT)
 
-      isRefBool = bool(isRef)
 
-      currentSlot[2] = typeName
-      currentSlot[3] = isRefBool
+def read(radio: CPSRadio, start_addr: int, length: int) -> bytes:
+    """Read a contiguous memory range from CPS memory."""
+    read_chunk_sz = 0x100
+    end_address = start_addr + length
+    ret = bytes()
 
-      if type != 0x11:
-        table.add_row(currentSlot)
+    for addr in range(start_addr, end_address, read_chunk_sz):
+        length = read_chunk_sz if (
+            addr + read_chunk_sz) < end_address else end_address - addr
 
-    print(table)
+        resp = radio.xfer(packet.Packet.readCodeplug(addr, length))
+
+        if isinstance(resp._content, packet.EmptyContent):
+            continue
+
+        ret += resp._content._content._payload
+
+    return ret
+
+
+def dump_cp_memory(args) -> None:
+    with CPSRadio(args.verbose) as radio:
+        data = read(radio, 0x0003ab2a, 1)
+        args.OUT_FILE.write(data)
+
+
+def read_digital_contacts(radio: CPSRadio) -> List[DigitalContact]:
+    num_contacts = struct.unpack('<H', read(radio, 0x65b5c, 2))[0]
+    contact_sz = DigitalContact.size()
+    table_sz = num_contacts * contact_sz
+
+    start_addr = 0x65b70
+    stop_addr = start_addr + table_sz
+
+    contacts: List[DigitalContact] = []
+
+    for contact_addr in range(start_addr, stop_addr, contact_sz):
+        contacts.append(DigitalContact(read(radio, contact_addr, contact_sz)))
+
+    return contacts
+
+
+def read_digital_channels(radio: CPSRadio) -> List[DigitalChannel]:
+    table_elements = struct.unpack('<H', read(radio, 0x3ab18, 2))[0]
+    element_sz = DigitalChannel.size()
+    start_addr = 0x3ab2a
+
+    channels: List[DigitalChannel] = []
+
+    for i in range(start_addr, start_addr + (table_elements * element_sz),
+                   element_sz):
+        data = read(radio, i, element_sz)
+
+        channels.append(DigitalChannel(data))
+
+    return channels
+
+
+def dump_digital_channels(args) -> None:
+    with CPSRadio(args.verbose) as radio:
+        contacts = read_digital_contacts(radio)
+        channels = read_digital_channels(radio)
+
+        table = PrettyTable(['Name', 'Tx Freqneucy', 'Rx Frequency', 'Contact',
+                             'Slot', 'Colour Code', 'Power', 'Scan', 'RO', 'TOT',
+                             'Admit', 'RxGL'])
+
+        for channel in channels:
+            table.add_row([channel.name, channel.tx_freq, channel.rx_freq,
+                           contacts[channel.tx_contact_idx - 1].name,
+                           channel.timeslot + 1, channel.colour_code,
+                           channel.power, channel.scan_list_idx,
+                           channel.rx_only, channel.tx_timeout,
+                           channel.tx_admit, channel.rx_group_list_idx])
+
+        print(table)
+
+
+def dump_contacts(args) -> None:
+    with CPSRadio(args.verbose) as radio:
+        contacts = read_digital_contacts(radio)
+
+        table = PrettyTable([
+            'Index', 'Name', 'Type', 'Is referenced', 'id', 'link'])
+
+        for contact in contacts:
+            if contact.call_type != DigitalContact.CALL_TYPE.IGNORE:
+                table.add_row([contact.idx, contact.name, contact.call_type,
+                               contact.is_ref, contact.id, contact.link])
+
+        print(table)
+
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Communicate with Hytera devices in CPS mode")
-    parser.add_argument("-v", "--verbose", action="store_true",
-                        help="Enable verbose mode (shows all packets sent and received).")
+    parser = argparse.ArgumentParser(
+        description="Communicate with Hytera devices in CPS mode")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose mode (shows all packets sent and received).")
 
-    subparsers = parser.add_subparsers(title="command",
-                                       dest="command",
-                                       required=True,
-                                       description="Commands that can be sent to the radio")
+    subparsers = parser.add_subparsers(
+        title="command",
+        dest="command",
+        required=True,
+        description="Commands that can be sent to the radio")
 
-    dumpCPMemoryParser = subparsers.add_parser("readCP",
-                                               help="Read codeplug memory to file.")
+    dumpCPMemoryParser = subparsers.add_parser(
+        "readCP", help="Read codeplug memory to file.")
 
-    dumpCPMemoryParser.add_argument("OUT_FILE",
-                                    type=argparse.FileType('bw'),
-                                    help="Output file where codeplug memory is written.")
+    dumpCPMemoryParser.add_argument(
+        "OUT_FILE",
+        type=argparse.FileType('bw'),
+        help="Output file where codeplug memory is written.")
 
-    dumpContactsParser = subparsers.add_parser("readContacts",
-                                               help="Read codeplug contacts and print to table.")
+    dumpContactsParser = subparsers.add_parser(
+        "dumpContacts", help="Read codeplug contacts and print to table.")
 
-    args = parser.parse_args()
+    dumpDigitalChannelParser = subparsers.add_parser(
+        "dumpDigitalChannels", help="Dump digitial channels")
+    parsedArgs = parser.parse_args()
 
-    if args.command == "readCP":
-      dump(args)
-    elif args.command == "readContacts":
-      dumpContacts(args)
+    if parsedArgs.command == "readCP":
+        dump_cp_memory(parsedArgs)
+    elif parsedArgs.command == "dumpContacts":
+        dump_contacts(parsedArgs)
+    elif parsedArgs.command == "dumpDigitalChannels":
+        dump_digital_channels(parsedArgs)

--- a/doc/reveng/hytera/cps.py
+++ b/doc/reveng/hytera/cps.py
@@ -111,7 +111,7 @@ def read(radio: CPSRadio, start_addr: int, length: int) -> bytes:
 
 def dump_cp_memory(args) -> None:
     with CPSRadio(args.verbose) as radio:
-        data = read(radio, 0x0003ab2a, 1)
+        data = read(radio, 0, 0x200000)
         args.OUT_FILE.write(data)
 
 

--- a/doc/reveng/hytera/extract_pcapng.py
+++ b/doc/reveng/hytera/extract_pcapng.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3 
 
-import pyshark
-import sys
+import pyshark  # type: ignore
 import binascii
 from packet import *
 
@@ -80,8 +79,8 @@ elif "fw_structure" == args.command:
       currentDataSource = HOST
 
     if currentDataSource != lastDataSource:
-      packet = FirmwarePacket.unpack(currentData)
-      print(packet)
+      fwPacket = FirmwarePacket.unpack(currentData)
+      print(fwPacket)
       currentData = bytes()
 
       lastDataSource = currentDataSource

--- a/doc/reveng/hytera/firmware.py
+++ b/doc/reveng/hytera/firmware.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
 
-import usb.core
-import usb.util
-import binascii
 import argparse
 import packet
-import struct
-import os
 from radio import FirmwareRadio
+
 
 def dump(args):
     with FirmwareRadio(args.verbose) as radio:

--- a/doc/reveng/hytera/pd785g/codeplug-format.md
+++ b/doc/reveng/hytera/pd785g/codeplug-format.md
@@ -129,9 +129,9 @@ struct digital_chan_t
   // byte 33
   // Using bitfields for single flags from LSB to MSB
   uint8_t rx_only    : 1,    /// 1=rx ony, 0=tx allowed
-          unk33      : 3,
+          unk33      : 2,
           power      : 1,    /// 1=High, 0=Low
-          ukn33_5    : 3;    /// <- Althoug not needed, it helps me to check whether I've got them all.
+          ukn33_5    : 4;    /// <- Althoug not needed, it helps me to check whether I've got them all.
   // byte 34
   uint16_t unk34;
   // byte 36


### PR DESCRIPTION
This includes:

 * Adding type hints to most modules
 * Making all classes in the `packet` module inherit from an abstract base class `AbstractPacket`.
 * Other bits of cleanup in some modules
 * Implement a `dumpDigitalChannels` command.  I've tried to get the output as close to the digital channel sectinon of `qdmr` as possible.  Here's an extact from my main codeplug:

```
+------------------+--------------+--------------+-----------------+------+-------------+-----------------+------+-------+-----+----------------+------+
|       Name       | Tx Freqneucy | Rx Frequency |     Contact     | Slot | Colour Code |      Power      | Scan |   RO  | TOT |     Admit      | RxGL |
+------------------+--------------+--------------+-----------------+------+-------------+-----------------+------+-------+-----+----------------+------+
|  Phoenix 235 UK  |  438800000   |  438800000   |      84400      |  2   |      1      |  PowerLevel.LOW |  0   | False |  36 | TxAdmit.ALWAYS |  0   |
| Phoenix 80 Chat  |  438800000   |  438800000   |      84401      |  2   |      1      |  PowerLevel.LOW |  0   | False |  36 | TxAdmit.ALWAYS |  0   |
| Phoenix 81 Chat  |  438800000   |  438800000   |      84402      |  2   |      1      |  PowerLevel.LOW |  0   | False |  36 | TxAdmit.ALWAYS |  0   |
| HS Brandmiester  |  438800000   |  438800000   |    TG9 Local    |  2   |      1      |  PowerLevel.LOW |  0   | False |  36 | TxAdmit.ALWAYS |  0   |
|    HS Phoenix    |  438800000   |  438800000   |   TG8 Regional  |  2   |      1      |  PowerLevel.LOW |  0   | False |  36 | TxAdmit.ALWAYS |  0   |
|    HS Hubnet     |  438800000   |  438800000   |    Hubnet UK    |  1   |      1      |  PowerLevel.LOW |  0   | False |  36 | TxAdmit.ALWAYS |  0   |
|  EL 9 S2 Local   |  430712500   |  439712500   |    TG9 Local    |  2   |      2      | PowerLevel.HIGH |  8   | False |  36 | TxAdmit.ALWAYS |  0   |
|  EL 9 S1 Local   |  430712500   |  439712500   |    TG9 Local    |  1   |      2      | PowerLevel.HIGH |  8   | False |  36 | TxAdmit.ALWAYS |  0   |
| EL 862 M62 Roam  |  430712500   |  439712500   |  TG862 M62 Roam |  2   |      2      | PowerLevel.HIGH |  1   | False |  36 | TxAdmit.ALWAYS |  0   |
| EL 820 NW Region |  430712500   |  439712500   |  TG820 North W  |  2   |      2      | PowerLevel.HIGH |  2   | False |  36 | TxAdmit.ALWAYS |  0   |
|   EL 83 UK UA    |  430712500   |  439712500   |    TG83 UK UA   |  1   |      2      | PowerLevel.HIGH |  8   | False |  36 | TxAdmit.ALWAYS |  0   |
|   EL 82 UK UA    |  430712500   |  439712500   |    TG82 UK UA   |  1   |      2      | PowerLevel.HIGH |  8   | False |  36 | TxAdmit.ALWAYS |  0   |
|   EL 81 UK UA    |  430712500   |  439712500   |    TG81 UK UA   |  1   |      2      | PowerLevel.HIGH |  8   | False |  36 | TxAdmit.ALWAYS |  0   |
|   EL 80 UK UA    |  430712500   |  439712500   |    TG80 UK UA   |  1   |      2      | PowerLevel.HIGH |  8   | False |  36 | TxAdmit.ALWAYS |  0   |
|    EL 235 UK     |  430712500   |  439712500   |  TG235 UK Wide  |  1   |      2      | PowerLevel.HIGH |  8   | False |  36 | TxAdmit.ALWAYS |  0   |
|   EL 129 WW UA   |  430712500   |  439712500   |   TG129 WW UA   |  1   |      2      | PowerLevel.HIGH |  8   | False |  36 | TxAdmit.ALWAYS |  0   |
|   EL 119 WW UA   |  430712500   |  439712500   |   TG119 WW UA   |  1   |      2      | PowerLevel.HIGH |  8   | False |  36 | TxAdmit.ALWAYS |  0   |
| EL 123 WW ENG UA |  430712500   |  439712500   | TG123 WW ENG UA |  1   |      2      | PowerLevel.HIGH |  8   | False |  36 | TxAdmit.ALWAYS |  0   |
```

Note that instead of referring to the `tx contact` by index, I crosreferenced to the actual contact table, just to make sure that the indexes did match up and all contacts look good.  Infact, I even spotted some errors with my codeplug with this!
