### PR TITLE
Add menu option to refresh callsign DB 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /snap/
 /stage/
 CMakeLists.txt.user
+/build/

--- a/shared/mainwindow.ui
+++ b/shared/mainwindow.ui
@@ -975,6 +975,7 @@
     <addaction name="actionCodeplugWizard"/>
     <addaction name="actionOpenCodeplug"/>
     <addaction name="actionSaveCodeplug"/>
+    <addaction name="actionRefreshCallsignDB"/>
     <addaction name="separator"/>
     <addaction name="actionQuit"/>
    </widget>
@@ -1197,6 +1198,18 @@
    </property>
    <property name="toolTip">
     <string>Upload call-sign DB to radio.</string>
+   </property>
+  </action>
+  <action name="actionRefreshCallsignDB">
+   <property name="icon">
+    <iconset resource="resources.qrc">
+     <normaloff>:/icons/people-2x.png</normaloff>:/icons/people-2x.png</iconset>
+   </property>
+   <property name="text">
+    <string>Refresh Callsign DB</string>
+   </property>
+   <property name="toolTip">
+    <string>Refreshes the downloaded callsign DB</string>
    </property>
   </action>
  </widget>

--- a/src/application.cc
+++ b/src/application.cc
@@ -135,6 +135,7 @@ Application::createMainWindow() {
   QAction *newCP   = _mainWindow->findChild<QAction*>("actionNewCodeplug");
   QAction *loadCP  = _mainWindow->findChild<QAction*>("actionOpenCodeplug");
   QAction *saveCP  = _mainWindow->findChild<QAction*>("actionSaveCodeplug");
+  QAction *refreshCallsignDB  = _mainWindow->findChild<QAction*>("actionRefreshCallsignDB");
 
   QAction *findDev = _mainWindow->findChild<QAction*>("actionDetectDevice");
   QAction *verCP   = _mainWindow->findChild<QAction*>("actionVerifyCodeplug");
@@ -150,6 +151,7 @@ Application::createMainWindow() {
   connect(newCP, SIGNAL(triggered()), this, SLOT(newCodeplug()));
   connect(loadCP, SIGNAL(triggered()), this, SLOT(loadCodeplug()));
   connect(saveCP, SIGNAL(triggered()), this, SLOT(saveCodeplug()));
+  connect(refreshCallsignDB, SIGNAL(triggered()), _users, SLOT(download()));
   connect(quit, SIGNAL(triggered()), this, SLOT(quitApplication()));
   connect(about, SIGNAL(triggered()), this, SLOT(showAbout()));
   connect(sett, SIGNAL(triggered()), this, SLOT(showSettings()));


### PR DESCRIPTION
First of all great tool 👍 .

I wanted to refresh the downloaded database because I was missing a callsign on my radio, but I've noticed that there was no option in the application to do so. After some digging around I found out that it does update every 30 days, or I could just delete the downloaded file. This PR changes that with a menu option.

Not sure if the File menu is the correct place for this option, if you have any suggestions let me know.

I also added the `build` folder to the gitignore.

Screenshot in Designer:
![image](https://user-images.githubusercontent.com/1395437/117424634-45385280-af22-11eb-83f2-260ffd9f18e4.png)
Screenshot in application:
![image](https://user-images.githubusercontent.com/1395437/117424703-5a14e600-af22-11eb-8abf-32e4ca993cec.png)
