### PR TITLE
Adjusted frequency range for 878 to include 220-225

### DIFF
--- a/lib/d878uv.cc
+++ b/lib/d878uv.cc
@@ -19,7 +19,7 @@ static Radio::Features _d878uv_features =
   .hasDigital  = true,
   .hasAnalog   = true,
 
-  .frequencyLimits = QVector<Radio::Features::FrequencyRange>{ {136., 174.}, {400., 480.} },
+  .frequencyLimits = QVector<Radio::Features::FrequencyRange>{ {136., 174.}, {220., 225.}, {400., 480.} },
 
   // general limits
   .maxRadioIDs        = 250,


### PR DESCRIPTION
The chip specification allows for 400-520, 136-174, and 220-225.  While the manufacturer does not recommend it, 1.25m is a semi-common amateur band.

https://www.iu2frl.it/anytone-878-test-mode/