### PR TITLE
Add udev rule comment for GD-77

### DIFF
--- a/dist/99-qdmr.rules
+++ b/dist/99-qdmr.rules
@@ -2,6 +2,7 @@
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="660", GROUP="dialout"
 
 # Baofeng RD-5R, TD-5R
+# Radioddity GD-77
 SUBSYSTEM=="usb", ATTRS{idVendor}=="15a2", ATTRS{idProduct}=="0073", MODE="660", GROUP="dialout"
 
 # Anytone AT-D868UV, AT-D878UV, etc


### PR DESCRIPTION
The Radioddity GD-77 is also a USB HID device with the same vendor and product id as the Baofeng RD-5R and TD-5R. I added a comment to the udev rule to make it clearer.