### PR TITLE
Fix compiler warnings "statement has no effect"

### DIFF
--- a/lib/anytone_extension.cc
+++ b/lib/anytone_extension.cc
@@ -167,7 +167,7 @@ void
 AnytoneDMRChannelExtension::enableDataACK(bool enable) {
   if (enable==_dataACK)
     return;
-  _dataACK == enable;
+  _dataACK = enable;
   emit modified(this);
 }
 
@@ -215,7 +215,7 @@ void
 AnytoneDMRChannelExtension::enableThroughMode(bool enable) {
   if (enable == _throughMode)
     return;
-  _throughMode == enable;
+  _throughMode = enable;
   emit modified(this);
 }
 


### PR DESCRIPTION
Fixes:
.../qdmr/lib/anytone_extension.cc: In member function ‘void AnytoneDMRChannelExtension::enableDataACK(bool)’: .../qdmr/lib/anytone_extension.cc:170:12: warning: statement has no effect [-Wunused-value]
  170 |   _dataACK == enable;
      |   ~~~~~~~~~^~~~~~~~~
.../qdmr/lib/anytone_extension.cc: In member function ‘void AnytoneDMRChannelExtension::enableThroughMode(bool)’:
.../qdmr/lib/anytone_extension.cc:218:16: warning: statement has no effect [-Wunused-value]
  218 |   _throughMode == enable;
      |   ~~~~~~~~~~~~~^~~~~~~~~