### PR TITLE
Visitor pattern

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -11,7 +11,8 @@ ENDIF(APPLE)
 SET(libdmrconf_SOURCES
     utils.cc crc32.cc signaling.cc addressmap.cc radiointerface.cc errorstack.cc
     radio.cc ${hid_SOURCES} dfu_libusb.cc usbserial.cc radioinfo.cc usbdevice.cc radiolimits.cc
-    csvreader.cc dfufile.cc userdatabase.cc logger.cc visitor.cc
+    csvreader.cc dfufile.cc userdatabase.cc logger.cc
+    visitor.cc configlabelingvisitor.cc
     configobject.cc configreference.cc config.cc radiosettings.cc contact.cc rxgrouplist.cc
     channel.cc zone.cc scanlist.cc gpssystem.cc codeplug.cc roamingzone.cc roamingchannel.cc
     callsigndb.cc talkgroupdatabase.cc radioid.cc encryptionextension.cc commercial_extension.cc
@@ -34,7 +35,8 @@ SET(libdmrconf_SOURCES
     dmr6x2uv.cc dmr6x2uv_codeplug.cc dmr6x2uv_limits.cc)
 SET(libdmrconf_MOC_HEADERS
     radio.hh ${hid_HEADERS} dfu_libusb.hh usbserial.hh radiolimits.hh
-    csvreader.hh dfufile.hh userdatabase.hh logger.hh visitor.hh
+    csvreader.hh dfufile.hh userdatabase.hh logger.hh
+    visitor.hh configlabelingvisitor.hh
     configobject.hh configreference.hh config.hh radiosettings.hh contact.hh rxgrouplist.hh
     channel.hh zone.hh scanlist.hh gpssystem.hh codeplug.hh roamingzone.hh roamingchannel.hh
     callsigndb.hh talkgroupdatabase.hh radioid.hh encryptionextension.hh commercial_extension.hh

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -11,7 +11,7 @@ ENDIF(APPLE)
 SET(libdmrconf_SOURCES
     utils.cc crc32.cc signaling.cc addressmap.cc radiointerface.cc errorstack.cc
     radio.cc ${hid_SOURCES} dfu_libusb.cc usbserial.cc radioinfo.cc usbdevice.cc radiolimits.cc
-    csvreader.cc dfufile.cc userdatabase.cc logger.cc
+    csvreader.cc dfufile.cc userdatabase.cc logger.cc visitor.cc
     configobject.cc configreference.cc config.cc radiosettings.cc contact.cc rxgrouplist.cc
     channel.cc zone.cc scanlist.cc gpssystem.cc codeplug.cc roamingzone.cc roamingchannel.cc
     callsigndb.cc talkgroupdatabase.cc radioid.cc encryptionextension.cc commercial_extension.cc
@@ -34,7 +34,7 @@ SET(libdmrconf_SOURCES
     dmr6x2uv.cc dmr6x2uv_codeplug.cc dmr6x2uv_limits.cc)
 SET(libdmrconf_MOC_HEADERS
     radio.hh ${hid_HEADERS} dfu_libusb.hh usbserial.hh radiolimits.hh
-    csvreader.hh dfufile.hh userdatabase.hh logger.hh
+    csvreader.hh dfufile.hh userdatabase.hh logger.hh visitor.hh
     configobject.hh configreference.hh config.hh radiosettings.hh contact.hh rxgrouplist.hh
     channel.hh zone.hh scanlist.hh gpssystem.hh codeplug.hh roamingzone.hh roamingchannel.hh
     callsigndb.hh talkgroupdatabase.hh radioid.hh encryptionextension.hh commercial_extension.hh

--- a/lib/channel.hh
+++ b/lib/channel.hh
@@ -30,7 +30,7 @@ class DMRRadioID;
  * @ingroup conf */
 class Channel: public ConfigObject
 {
-	Q_OBJECT
+  Q_OBJECT
 
   /** The receive frequency of the channel. */
   Q_PROPERTY(double rxFrequency READ rxFrequency WRITE setRXFrequency)
@@ -50,6 +50,9 @@ class Channel: public ConfigObject
   Q_PROPERTY(OpenGD77ChannelExtension* openGD77 READ openGD77ChannelExtension WRITE setOpenGD77ChannelExtension)
   /** The TyT channel extension. */
   Q_PROPERTY(TyTChannelExtension* tyt READ tytChannelExtension WRITE setTyTChannelExtension)
+
+  /** Specifies the prefix for every ID assigned to every channel during serialization. */
+  Q_CLASSINFO("IdPrefix", "ch")
 
 public:
   /** Possible power settings. */

--- a/lib/commercial_extension.cc
+++ b/lib/commercial_extension.cc
@@ -56,7 +56,8 @@ void
 CommercialChannelExtension::setEncryptionKeyRef(EncryptionKeyReference *ref) {
   if (nullptr == ref)
     setEncryptionKey(nullptr);
-  setEncryptionKey(ref->as<EncryptionKey>());
+  else
+    setEncryptionKey(ref->as<EncryptionKey>());
 }
 
 EncryptionKey *

--- a/lib/configlabelingvisitor.cc
+++ b/lib/configlabelingvisitor.cc
@@ -1,0 +1,37 @@
+#include "configlabelingvisitor.hh"
+
+ConfigLabelingVisitor::ConfigLabelingVisitor(ConfigItem::Context &context)
+  : Visitor(), _context(context)
+{
+  // pass..
+}
+
+bool
+ConfigLabelingVisitor::processItem(ConfigItem *item, const ErrorStack &err)
+{
+  // First, check if item is an ConfigObject
+  if (item->is<ConfigObject>()) {
+    ConfigObject *obj = item->as<ConfigObject>();
+    QString prefix = obj->idPrefix();
+
+    // If no prefix is set -> skip.
+    if (prefix.isEmpty())
+      return Visitor::processItem(item, err);
+
+    // Find unused ID
+    unsigned n=1;
+    QString id=QString("%1%2").arg(prefix).arg(n);
+    while (_context.contains(id))
+      id=QString("%1%2").arg(prefix).arg(++n);
+
+    // Add to context
+    if (! _context.add(id, obj)) {
+      if (_context.contains(obj))
+        errMsg(err) << "Object already in context with id '" << _context.getId(obj) << "'.";
+      errMsg(err) << "Cannot add element '" << id << "' to context.";
+      return false;
+    }
+  }
+
+  return Visitor::processItem(item, err);
+}

--- a/lib/configlabelingvisitor.hh
+++ b/lib/configlabelingvisitor.hh
@@ -1,0 +1,29 @@
+#ifndef CONFIGLABELINGVISITOR_HH
+#define CONFIGLABELINGVISITOR_HH
+
+#include "visitor.hh"
+#include "configobject.hh"
+
+/** A visitor to label the entire configuration.
+ * That is, assigning unique labels to each @c ConfigObject within the configuration.
+ * @ingroup conf */
+class ConfigLabelingVisitor: protected Visitor
+{
+protected:
+  /** Hidden constructor. Use the static method @c label to label the configuration. */
+  ConfigLabelingVisitor(ConfigItem::Context &context);
+
+public:
+  /** Lables the configuration and stores the labels in the given context. */
+  static bool label(Config *config, ConfigItem::Context &context);
+
+protected:
+  bool processItem(ConfigItem *item, const ErrorStack &err=ErrorStack());
+
+protected:
+  /** Holds a weak reference to the parser/serializer context.
+   * That is, the id<->obj table. */
+  ConfigItem::Context &_context;
+};
+
+#endif // CONFIGLABELINGVISITOR_HH

--- a/lib/configobject.cc
+++ b/lib/configobject.cc
@@ -935,14 +935,14 @@ ConfigItem::longDescription(const QMetaProperty &prop) const {
 /* ********************************************************************************************* *
  * Implementation of ConfigObject
  * ********************************************************************************************* */
-ConfigObject::ConfigObject(const QString &idBase, QObject *parent)
-  : ConfigItem(parent), _idBase(idBase), _name()
+ConfigObject::ConfigObject(QObject *parent)
+  : ConfigItem(parent), _name()
 {
   // pass...
 }
 
-ConfigObject::ConfigObject(const QString &name, const QString &idBase, QObject *parent)
-  : ConfigItem(parent), _idBase(idBase), _name(name)
+ConfigObject::ConfigObject(const QString &name, QObject *parent)
+  : ConfigItem(parent), _name(name)
 {
   // pass...
 }
@@ -960,16 +960,18 @@ ConfigObject::setName(const QString &name) {
   emit modified(this);
 }
 
+QString
+ConfigObject::idPrefix() const {
+  return findIdPrefix(this->metaObject());
+}
+
 bool
 ConfigObject::label(ConfigObject::Context &context, const ErrorStack &err) {
-  // With empty ID base, skip labeling.
-  if (_idBase.isEmpty())
-    return true;
-
   unsigned n=1;
-  QString id=QString("%1%2").arg(_idBase).arg(n);
+  QString prefix = this->idPrefix();
+  QString id=QString("%1%2").arg(prefix).arg(n);
   while (context.contains(id)) {
-    id=QString("%1%2").arg(_idBase).arg(++n);
+    id=QString("%1%2").arg(prefix).arg(++n);
   }
 
   if (! context.add(id, this)) {
@@ -1008,6 +1010,18 @@ ConfigObject::populate(YAML::Node &node, const Context &context, const ErrorStac
   if (context.contains(this))
     node["id"] = context.getId(this).toStdString();
   return ConfigItem::populate(node, context, err);
+}
+
+QString
+ConfigObject::findIdPrefix(const QMetaObject *meta) {
+  for (int i=meta->classInfoOffset(); i<meta->classInfoCount(); i++) {
+    if (0 == strcmp("IdPrefix", meta->classInfo(i).name())) {
+      return meta->classInfo(i).value();
+    }
+  }
+  if (meta->superClass())
+    return findIdPrefix(meta->superClass());
+  return "";
 }
 
 

--- a/lib/configobject.hh
+++ b/lib/configobject.hh
@@ -202,17 +202,18 @@ class ConfigObject: public ConfigItem
   /** The name of the object. */
   Q_PROPERTY(QString name READ name WRITE setName)
 
+  /** Specifies the prefix for every ID assigned to every object during serialization. */
+  Q_CLASSINFO("IdPrefix", "obj")
+
 protected:
   /** Hidden constructor.
-   * @param idBase Prefix for all generated IDs. If empty, no ID gets generated.
    * @param parent Specifies the QObject parent. */
-  ConfigObject(const QString &idBase="id", QObject *parent = nullptr);
+  ConfigObject(QObject *parent = nullptr);
 
   /** Hidden constructor.
    * @param name Name of the object.
-   * @param idBase Prefix for all generated IDs. If empty, no ID gets generated.
    * @param parent Specifies the QObject parent. */
-  ConfigObject(const QString &name, const QString &idBase="id", QObject *parent = nullptr);
+  ConfigObject(const QString &name, QObject *parent = nullptr);
 
 public:
   /** Returns the name of the object. */
@@ -221,16 +222,18 @@ public:
   virtual void setName(const QString &name);
 
 public:
+  /** Returns the ID prefix for this object. */
+  QString idPrefix() const;
   bool label(Context &context, const ErrorStack &err=ErrorStack());
   bool parse(const YAML::Node &node, Context &ctx, const ErrorStack &err=ErrorStack());
 
 protected:
   virtual bool populate(YAML::Node &node, const Context &context, const ErrorStack &err=ErrorStack());
 
+  /** Helper for find the @c IdPrefix class info in the class hierachy. */
+  static QString findIdPrefix(const QMetaObject* meta);
+
 protected:
-  /** Holds the base string to derive an ID from. All objects need some ID to be referenced within
-   * a codeplug file. */
-  QString _idBase;
   /** Holds the name of the object. */
   QString _name;
 };
@@ -241,7 +244,7 @@ protected:
  * properties. */
 class ConfigExtension : public ConfigItem
 {
-Q_OBJECT
+  Q_OBJECT
 
 protected:
   /** Hidden constructor. */

--- a/lib/contact.cc
+++ b/lib/contact.cc
@@ -9,13 +9,13 @@
  * Implementation of Contact
  * ********************************************************************************************* */
 Contact::Contact(QObject *parent)
-  : ConfigObject("cont", parent), _ring(false)
+  : ConfigObject(parent), _ring(false)
 {
   // pass...
 }
 
 Contact::Contact(const QString &name, bool rxTone, QObject *parent)
-  : ConfigObject(name, "cont", parent), _ring(rxTone)
+  : ConfigObject(name, parent), _ring(rxTone)
 {
   // pass...
 }

--- a/lib/contact.hh
+++ b/lib/contact.hh
@@ -16,7 +16,8 @@ class Config;
  * @ingroup conf */
 class Contact: public ConfigObject
 {
-	Q_OBJECT
+  Q_OBJECT
+  Q_CLASSINFO("IdPrefix", "cont");
 
   /** If @c true and supported by radio, ring on call from this contact. */
   Q_PROPERTY(bool ring READ ring WRITE setRing)

--- a/lib/encryptionextension.cc
+++ b/lib/encryptionextension.cc
@@ -6,7 +6,7 @@
  * Implementation of EncryptionKey
  * ********************************************************************************************* */
 EncryptionKey::EncryptionKey(QObject *parent)
-  : ConfigObject("key", parent)
+  : ConfigObject(parent)
 {
   // pass...
 }

--- a/lib/encryptionextension.hh
+++ b/lib/encryptionextension.hh
@@ -9,6 +9,7 @@
 class EncryptionKey: public ConfigObject
 {
   Q_OBJECT
+  Q_CLASSINFO("IdPrefix", "key")
 
   /** The key representation as a hex string. */
   Q_PROPERTY(QString key READ toHex WRITE fromHex)
@@ -50,7 +51,7 @@ class DMREncryptionKey: public EncryptionKey
 
 public:
   /** Empty constructor. */
-   Q_INVOKABLE explicit DMREncryptionKey(QObject *parent=nullptr);
+  Q_INVOKABLE explicit DMREncryptionKey(QObject *parent=nullptr);
 
   ConfigItem *clone() const;
   virtual void fromHex(const QString &hex);
@@ -77,7 +78,7 @@ class AESEncryptionKey: public EncryptionKey
 
 public:
   /** Empty constructor. */
-   Q_INVOKABLE explicit AESEncryptionKey(QObject *parent=nullptr);
+  Q_INVOKABLE explicit AESEncryptionKey(QObject *parent=nullptr);
 
   ConfigItem *clone() const;
   virtual void fromHex(const QString &hex);

--- a/lib/gpssystem.cc
+++ b/lib/gpssystem.cc
@@ -9,13 +9,13 @@
  * Implementation of PositioningSystem
  * ********************************************************************************************* */
 PositioningSystem::PositioningSystem(QObject *parent)
-  : ConfigObject("aprs", parent), _period(0)
+  : ConfigObject(parent), _period(0)
 {
   // pass...
 }
 
 PositioningSystem::PositioningSystem(const QString &name, unsigned period, QObject *parent)
-  : ConfigObject(name, "aprs", parent), _period(period)
+  : ConfigObject(name, parent), _period(period)
 {
   // pass...
 }

--- a/lib/gpssystem.hh
+++ b/lib/gpssystem.hh
@@ -15,6 +15,7 @@ class FMChannel;
 class PositioningSystem: public ConfigObject
 {
   Q_OBJECT
+  Q_CLASSINFO("IdPrefix", "aprs")
 
   /** The update period in seconds. */
   Q_PROPERTY(unsigned period READ period WRITE setPeriod)

--- a/lib/opengd77_extension.hh
+++ b/lib/opengd77_extension.hh
@@ -40,7 +40,7 @@ public:
     P3W     =  7,              ///< About 3W.
     P4W     =  8,              ///< About 4W.
     P5W     =  9,              ///< About 5W.
-    Max     = 10,              ///< Maximum power (5.5W on UHF, 7W on VHF).
+    Max     = 10               ///< Maximum power (5.5W on UHF, 7W on VHF).
   };
   Q_ENUM(Power)
 

--- a/lib/radioid.cc
+++ b/lib/radioid.cc
@@ -6,14 +6,14 @@
 /* ********************************************************************************************* *
  * Implementation of RadioID
  * ********************************************************************************************* */
-RadioID::RadioID(const QString &idBase, QObject *parent)
-  : ConfigObject(idBase, parent)
+RadioID::RadioID(QObject *parent)
+  : ConfigObject(parent)
 {
   // pass...
 }
 
-RadioID::RadioID(const QString &name, const QString &idBase, QObject *parent)
-  : ConfigObject(name, idBase, parent)
+RadioID::RadioID(const QString &name, QObject *parent)
+  : ConfigObject(name, parent)
 {
   // pass...
 }
@@ -23,13 +23,13 @@ RadioID::RadioID(const QString &name, const QString &idBase, QObject *parent)
  * Implementation of DMRRadioID
  * ********************************************************************************************* */
 DMRRadioID::DMRRadioID(QObject *parent)
-  : RadioID("id", parent), _number(0)
+  : RadioID(parent), _number(0)
 {
   // pass...
 }
 
 DMRRadioID::DMRRadioID(const QString &name, uint32_t id, QObject *parent)
-  : RadioID(name, "id", parent), _number(id)
+  : RadioID(name, parent), _number(id)
 {
   // pass...
 }
@@ -122,13 +122,13 @@ DefaultRadioID::get() {
  * Implementation of DTMFRadioID
  * ********************************************************************************************* */
 DTMFRadioID::DTMFRadioID(QObject *parent)
-  : RadioID("id", parent)
+  : RadioID(parent)
 {
   // pass...
 }
 
 DTMFRadioID::DTMFRadioID(const QString &name, const QString &number, QObject *parent)
-  : RadioID(name, "id", parent), _number()
+  : RadioID(name, parent), _number()
 {
   setNumber(number.simplified());
 }

--- a/lib/radioid.hh
+++ b/lib/radioid.hh
@@ -17,9 +17,9 @@ class RadioID: public ConfigObject
 protected:
   /** Hidden default constructor.
    * Use one of the derived classes to instantiate radio IDs. */
-  explicit RadioID(const QString &idBase, QObject *parent=nullptr);
+  explicit RadioID(QObject *parent=nullptr);
   /** Hidden constructor with name. */
-  RadioID(const QString &name, const QString &idBase, QObject *parent=nullptr);
+  RadioID(const QString &name, QObject *parent=nullptr);
 };
 
 
@@ -31,6 +31,7 @@ protected:
 class DMRRadioID : public RadioID
 {
   Q_OBJECT
+  Q_CLASSINFO("IdPrefix", "id")
 
   /** The number of the radio ID. */
   Q_PROPERTY(unsigned number READ number WRITE setNumber)
@@ -89,6 +90,7 @@ private:
 class DTMFRadioID: public RadioID
 {
   Q_OBJECT
+  Q_CLASSINFO("IdPrefix", "dtmf")
 
   /** The DTMF number of the radio ID. */
   Q_PROPERTY(QString number READ number WRITE setNumber)

--- a/lib/radiolimits.hh
+++ b/lib/radiolimits.hh
@@ -376,7 +376,7 @@ protected:
 
 /** Specialization for transmit frequency limits.
  * The verification is only performed if the channel is not "RX Only".
- * @ingroup limits. */
+ * @ingroup limits */
 class RadioLimitTransmitFrequencies: public RadioLimitFrequencies
 {
   Q_OBJECT

--- a/lib/roamingchannel.cc
+++ b/lib/roamingchannel.cc
@@ -4,14 +4,14 @@
  * Implementation of RoamingChannel
  * ********************************************************************************************* */
 RoamingChannel::RoamingChannel(QObject *parent)
-  : ConfigObject("rc", parent), _rxFrequency(0), _txFrequency(0), _overrideColorCode(false),
+  : ConfigObject(parent), _rxFrequency(0), _txFrequency(0), _overrideColorCode(false),
     _colorCode(0), _overrideTimeSlot(false), _timeSlot(DMRChannel::TimeSlot::TS1)
 {
   // pass...
 }
 
 RoamingChannel::RoamingChannel(const RoamingChannel &other, QObject *parent)
-  : ConfigObject("rc", parent)
+  : ConfigObject(parent)
 {
   copy(other);
 }

--- a/lib/roamingchannel.hh
+++ b/lib/roamingchannel.hh
@@ -15,6 +15,7 @@
 class RoamingChannel : public ConfigObject
 {
   Q_OBJECT
+  Q_CLASSINFO("IdPrefix", "rch")
 
   /** Holds the RX frequency in MHz. */
   Q_PROPERTY(double rxFrequency READ rxFrequency WRITE setRXFrequency)

--- a/lib/roamingzone.cc
+++ b/lib/roamingzone.cc
@@ -13,7 +13,7 @@ RoamingZone::RoamingZone(QObject *parent)
 }
 
 RoamingZone::RoamingZone(const QString &name, QObject *parent)
-  : ConfigObject(name, "roam", parent), _channel()
+  : ConfigObject(name, parent), _channel()
 {
   // pass...
 }

--- a/lib/roamingzone.hh
+++ b/lib/roamingzone.hh
@@ -14,6 +14,7 @@
 class RoamingZone : public ConfigObject
 {
   Q_OBJECT
+  Q_CLASSINFO("IdPrefix", "roam")
 
   /** The channels in the roaming zone.
    * @todo This property is marked non-scriptable to handle references to DMR channels before

--- a/lib/rxgrouplist.cc
+++ b/lib/rxgrouplist.cc
@@ -17,7 +17,7 @@
  * Implementation of RXGroupList
  * ********************************************************************************************* */
 RXGroupList::RXGroupList(QObject *parent)
-  : ConfigObject("grp", parent), _contacts()
+  : ConfigObject(parent), _contacts()
 {
   connect(&_contacts, SIGNAL(elementModified(int)), this, SLOT(onModified()));
   connect(&_contacts, SIGNAL(elementRemoved(int)), this, SLOT(onModified()));
@@ -25,7 +25,7 @@ RXGroupList::RXGroupList(QObject *parent)
 }
 
 RXGroupList::RXGroupList(const QString &name, QObject *parent)
-  : ConfigObject(name, "grp", parent), _contacts()
+  : ConfigObject(name, parent), _contacts()
 {
   connect(&_contacts, SIGNAL(elementModified(int)), this, SLOT(onModified()));
   connect(&_contacts, SIGNAL(elementRemoved(int)), this, SLOT(onModified()));

--- a/lib/rxgrouplist.hh
+++ b/lib/rxgrouplist.hh
@@ -13,7 +13,8 @@ class DMRContact;
  * @ingroup conf */
 class RXGroupList: public ConfigObject
 {
-	Q_OBJECT
+  Q_OBJECT
+  Q_CLASSINFO("IdPrefix", "grp");
 
   /** The list of contacts. */
   Q_PROPERTY(DMRContactRefList* contacts READ contacts)

--- a/lib/scanlist.cc
+++ b/lib/scanlist.cc
@@ -15,23 +15,23 @@
  * Implementation of ScanList
  * ********************************************************************************************* */
 ScanList::ScanList(QObject *parent)
-  : ConfigObject("scan", parent), _channels(), _primary(), _secondary(), _revert(), _tyt(nullptr)
+  : ConfigObject(parent), _channels(), _primary(), _secondary(), _revert(), _tyt(nullptr)
 {
   // Register "selected" channel tags for primary, secondary, revert and the channel list.
-  Context::setTag(metaObject()->className(), "primary", "!selected", SelectedChannel::get());
-  Context::setTag(metaObject()->className(), "secondary", "!selected", SelectedChannel::get());
-  Context::setTag(metaObject()->className(), "revert", "!selected", SelectedChannel::get());
-  Context::setTag(metaObject()->className(), "channels", "!selected", SelectedChannel::get());
+  Context::setTag(staticMetaObject.className(), "primary", "!selected", SelectedChannel::get());
+  Context::setTag(staticMetaObject.className(), "secondary", "!selected", SelectedChannel::get());
+  Context::setTag(staticMetaObject.className(), "revert", "!selected", SelectedChannel::get());
+  Context::setTag(staticMetaObject.className(), "channels", "!selected", SelectedChannel::get());
 }
 
 ScanList::ScanList(const QString &name, QObject *parent)
-  : ConfigObject(name, "scan", parent), _channels(), _primary(), _secondary(), _revert(), _tyt(nullptr)
+  : ConfigObject(name, parent), _channels(), _primary(), _secondary(), _revert(), _tyt(nullptr)
 {
   // Register "selected" channel tags for primary, secondary, revert and the channel list.
-  Context::setTag(metaObject()->className(), "primary", "!selected", SelectedChannel::get());
-  Context::setTag(metaObject()->className(), "secondary", "!selected", SelectedChannel::get());
-  Context::setTag(metaObject()->className(), "revert", "!selected", SelectedChannel::get());
-  Context::setTag(metaObject()->className(), "channels", "!selected", SelectedChannel::get());
+  Context::setTag(staticMetaObject.className(), "primary", "!selected", SelectedChannel::get());
+  Context::setTag(staticMetaObject.className(), "secondary", "!selected", SelectedChannel::get());
+  Context::setTag(staticMetaObject.className(), "revert", "!selected", SelectedChannel::get());
+  Context::setTag(staticMetaObject.className(), "channels", "!selected", SelectedChannel::get());
 }
 
 ScanList &

--- a/lib/scanlist.hh
+++ b/lib/scanlist.hh
@@ -13,7 +13,8 @@ class Channel;
  * @ingroup conf */
 class ScanList : public ConfigObject
 {
-	Q_OBJECT
+  Q_OBJECT
+  Q_CLASSINFO("IdPrefix", "scan")
 
   /** The primary channel. */
   Q_PROPERTY(ChannelReference* primary READ primary)

--- a/lib/visitor.cc
+++ b/lib/visitor.cc
@@ -1,0 +1,185 @@
+#include "visitor.hh"
+#include "config.hh"
+#include "configobject.hh"
+#include "configreference.hh"
+#include "logger.hh"
+
+Visitor::Visitor()
+{
+  // Pass...
+}
+
+Visitor::~Visitor() {
+  // pass...
+}
+
+bool
+Visitor::process(Config *config, const ErrorStack &err) {
+  return this->processItem(config, err);
+}
+
+bool
+Visitor::processItem(ConfigItem *item, const ErrorStack &err) {
+  // Serialize all properties
+  const QMetaObject *meta = item->metaObject();
+  for (int p=QObject::staticMetaObject.propertyCount(); p<meta->propertyCount(); p++) {
+    QMetaProperty prop = meta->property(p);
+    if (! prop.isValid()) {
+      logWarn() << "Found invalid property at index " << p << " in an instance of '"
+                << meta->className() << "'. Skip.";
+      continue;
+    }
+
+    if (! this->processProperty(item, prop, err)) {
+      errMsg(err) << "While processing property '" << prop.name() << "' of '"
+                  << meta->className() << "'.";
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+Visitor::processProperty(ConfigItem *item, const QMetaProperty &prop, const ErrorStack &err) {
+  if (prop.isEnumType()) {
+    if (! this->processEnum(item, prop, err)) {
+      errMsg(err) << "While processing enum '" << prop.name() << "' of '"
+                  << item->metaObject()->className() << "'.";
+      return false;
+    }
+  } else if (QString("bool") == prop.typeName()) {
+    if (! this->processBool(item, prop, err)) {
+      errMsg(err) << "While processing boolean '" << prop.name() << "' of '"
+                  << item->metaObject()->className() << "'.";
+      return false;
+    }
+  } else if (QString("int") == prop.typeName()) {
+    if (! this->processInt(item, prop, err)) {
+      errMsg(err) << "While processing integer '" << prop.name() << "' of '"
+                  << item->metaObject()->className() << "'.";
+      return false;
+    }
+  } else if (QString("uint") == prop.typeName()) {
+    if (! this->processUInt(item, prop, err)) {
+      errMsg(err) << "While processing unsigned integer '" << prop.name() << "' of '"
+                  << item->metaObject()->className() << "'.";
+      return false;
+    }
+  } else if (QString("double") == prop.typeName()) {
+    if (! this->processDouble(item, prop, err)) {
+      errMsg(err) << "While processing double '" << prop.name() << "' of '"
+                  << item->metaObject()->className() << "'.";
+      return false;
+    }
+  } else if (QString("QString") == prop.typeName()) {
+    if (! this->processBool(item, prop, err)) {
+      errMsg(err) << "While processing string '" << prop.name() << "' of '"
+                  << item->metaObject()->className() << "'.";
+      return false;
+    }
+  } else if (ConfigObjectReference *ref = prop.read(item).value<ConfigObjectReference *>()) {
+    if (! this->processReference(ref, err)) {
+      errMsg(err) << "While processing reference '" << prop.name() << "' of '"
+                  << item->metaObject()->className() << "'.";
+      return false;
+    }
+  } else if (ConfigObjectRefList *refs = prop.read(item).value<ConfigObjectRefList *>()) {
+    if (! this->processList(refs, err)) {
+      errMsg(err) << "While processing reference list '" << prop.name() << "' of '"
+                  << item->metaObject()->className() << "'.";
+      return false;
+    }
+  } else if (propIsInstance<ConfigItem>(prop)) {
+    if (! this->processItem(prop.read(item).value<ConfigItem *>(), err)) {
+      errMsg(err) << "While processing item '" << prop.name() << "' of '"
+                  << item->metaObject()->className() << "'.";
+      return false;
+    }
+  } else if (ConfigObjectList *lst = prop.read(item).value<ConfigObjectList *>()) {
+    if (! this->processList(lst, err)) {
+      errMsg(err) << "While processing reference list '" << prop.name() << "' of '"
+                  << item->metaObject()->className() << "'.";
+      return false;
+    }
+  } else {
+    if (! this->processUnknownType(item, prop, err)) {
+      errMsg(err) << "While processing property '" << prop.name() << "' of '"
+                  << item->metaObject()->className() << "' of unknown type.";
+      return false;
+
+    }
+  }
+
+  return true;
+}
+
+bool
+Visitor::processBool(ConfigItem *parent, const QMetaProperty &prop, const ErrorStack &err) {
+  Q_UNUSED(parent); Q_UNUSED(prop); Q_UNUSED(err)
+  // Does nothing, return true;
+  return true;
+}
+
+bool
+Visitor::processEnum(ConfigItem *parent, const QMetaProperty &prop, const ErrorStack &err) {
+  Q_UNUSED(parent); Q_UNUSED(prop); Q_UNUSED(err)
+  // Does nothing, return true;
+  return true;
+}
+
+bool
+Visitor::processInt(ConfigItem *parent, const QMetaProperty &prop, const ErrorStack &err) {
+  Q_UNUSED(parent); Q_UNUSED(prop); Q_UNUSED(err)
+  // Does nothing, return true;
+  return true;
+}
+
+bool
+Visitor::processUInt(ConfigItem *parent, const QMetaProperty &prop, const ErrorStack &err) {
+  Q_UNUSED(parent); Q_UNUSED(prop); Q_UNUSED(err)
+  // Does nothing, return true;
+  return true;
+}
+
+bool
+Visitor::processDouble(ConfigItem *parent, const QMetaProperty &prop, const ErrorStack &err) {
+  Q_UNUSED(parent); Q_UNUSED(prop); Q_UNUSED(err)
+  // Does nothing, return true;
+  return true;
+}
+
+bool
+Visitor::processString(ConfigItem *parent, const QMetaProperty &prop, const ErrorStack &err) {
+  Q_UNUSED(parent); Q_UNUSED(prop); Q_UNUSED(err)
+  // Does nothing, return true;
+  return true;
+}
+
+bool
+Visitor::processUnknownType(ConfigItem *parent, const QMetaProperty &prop, const ErrorStack &err) {
+  errMsg(err) << "Cannot handle property '" << prop.name() << "' of '"
+              << parent->metaObject()->className() << "': Unknown type '"
+              << prop.typeName()  << "'.";
+  return false;
+}
+
+bool
+Visitor::processReference(ConfigObjectReference* ref, const ErrorStack &err) {
+  Q_UNUSED(ref); Q_UNUSED(err)
+  // Does nothing, returns true;
+  return true;
+}
+
+bool
+Visitor::processList(AbstractConfigObjectList *list, const ErrorStack &err) {
+  if (ConfigObjectList *objList = qobject_cast<ConfigObjectList *>(list)) {
+    for (int i=0; i<objList->count(); i++) {
+      if (! this->processItem(objList->get(i), err)) {
+        errMsg(err) << "While processing object list.";
+        return false;
+      }
+    }
+  }
+  return true;
+}
+

--- a/lib/visitor.hh
+++ b/lib/visitor.hh
@@ -1,0 +1,93 @@
+#ifndef VISITOR_HH
+#define VISITOR_HH
+
+#include <QObject>
+#include "errorstack.hh"
+
+// Forward declarations
+class Config;
+class ConfigItem;
+class ConfigObjectReference;
+class AbstractConfigObjectList;
+
+
+/** Base visitor class for the config tree.
+ *
+ *  This class can be used to implement a convenient tree taversal for the entrie configuration.
+ *
+ * @ingroup config */
+class Visitor
+{
+protected:
+  /** Hidden constructor. */
+  Visitor();
+
+public:
+  /** Destructor. */
+  virtual ~Visitor();
+
+  /** Traverses the properties of the configuration recursively.
+   * @returns @c true on success. Error information can be found in the error stack, if passed. */
+  virtual bool process(Config *config, const ErrorStack &err=ErrorStack());
+
+  /** Processes the specified property of the item.
+   * This method dispatches to the type-specific methods like @c processEnum, @c processBool,
+   * @c processInt, @c processUInt, @c processDouble, @c processString, @c processItem,
+   * @c processReference, @c processList, and @c processUnknownType, depending on the type of the
+   * property. Do not override this method unless you need to handle all properties differently. */
+  virtual bool processProperty(ConfigItem *item, const QMetaProperty &prop, const ErrorStack &err=ErrorStack());
+
+  /** Handles an enum typed property.
+   * @param item Specifies the config item holding this property.
+   * @param prop Specifies the property.
+   * @param err Specifies the error stack to pass on. */
+  virtual bool processEnum(ConfigItem *item, const QMetaProperty &prop, const ErrorStack &err=ErrorStack());
+  /** Handles a boolean typed property.
+   * @param item Specifies the config item holding this property.
+   * @param prop Specifies the property.
+   * @param err Specifies the error stack to pass on. */
+  virtual bool processBool(ConfigItem *item, const QMetaProperty &prop, const ErrorStack &err=ErrorStack());
+  /** Handles an integer typed property.
+   * @param item Specifies the config item holding this property.
+   * @param prop Specifies the property.
+   * @param err Specifies the error stack to pass on. */
+  virtual bool processInt(ConfigItem *item, const QMetaProperty &prop, const ErrorStack &err=ErrorStack());
+  /** Handles an unsigned integer typed property.
+   * @param item Specifies the config item holding this property.
+   * @param prop Specifies the property.
+   * @param err Specifies the error stack to pass on. */
+  virtual bool processUInt(ConfigItem *item, const QMetaProperty &prop, const ErrorStack &err=ErrorStack());
+  /** Handles a double precision float typed property.
+   * @param item Specifies the config item holding this property.
+   * @param prop Specifies the property.
+   * @param err Specifies the error stack to pass on. */
+  virtual bool processDouble(ConfigItem *item, const QMetaProperty &prop, const ErrorStack &err=ErrorStack());
+  /** Handles a string typed property.
+   * @param item Specifies the config item holding this property.
+   * @param prop Specifies the property.
+   * @param err Specifies the error stack to pass on. */
+  virtual bool processString(ConfigItem *item, const QMetaProperty &prop, const ErrorStack &err=ErrorStack());
+  /** Handles a property of unknown type.
+   * Returns always @c false.
+   * @param item Specifies the config item holding this property.
+   * @param prop Specifies the property.
+   * @param err Specifies the error stack to pass on. */
+  virtual bool processUnknownType(ConfigItem *item, const QMetaProperty &prop, const ErrorStack &err=ErrorStack());
+
+  /** Traverses the specified config item.
+   * This method calles @c processProperty on all properties of the item. */
+  virtual bool processItem(ConfigItem *item, const ErrorStack &err=ErrorStack());
+
+  /** Traverses the list of objects or references.
+   * If @c list is a list of @c ConfigItem, the visitor will traverse those by calling
+   * @c processItem on every of these element. If it is a list of @c ConfigObjectRef references,
+   * the visitor stop here and simply return @c true. By default, the visitor does not follow
+   * references. */
+  virtual bool processList(AbstractConfigObjectList *list, const ErrorStack &err=ErrorStack());
+
+  /** Handles references to config objects.
+   * By default, the method will simply return @c true. The visitor does not follow references. */
+  virtual bool processReference(ConfigObjectReference*, const ErrorStack &err=ErrorStack());
+};
+
+#endif // VISITOR_HH

--- a/lib/zone.cc
+++ b/lib/zone.cc
@@ -16,7 +16,7 @@
  * Implementation of Zone
  * ********************************************************************************************* */
 Zone::Zone(QObject *parent)
-  : ConfigObject("zone", parent), _A(), _B(), _anytone(nullptr)
+  : ConfigObject(parent), _A(), _B(), _anytone(nullptr)
 {
   connect(&_A, SIGNAL(elementAdded(int)), this, SIGNAL(modified()));
   connect(&_A, SIGNAL(elementRemoved(int)), this, SIGNAL(modified()));
@@ -25,7 +25,7 @@ Zone::Zone(QObject *parent)
 }
 
 Zone::Zone(const QString &name, QObject *parent)
-  : ConfigObject(name, "zone", parent), _A(), _B(), _anytone(nullptr)
+  : ConfigObject(name, parent), _A(), _B(), _anytone(nullptr)
 {
   connect(&_A, SIGNAL(elementAdded(int)), this, SIGNAL(modified()));
   connect(&_A, SIGNAL(elementRemoved(int)), this, SIGNAL(modified()));

--- a/lib/zone.hh
+++ b/lib/zone.hh
@@ -14,7 +14,8 @@ class Config;
  * @ingroup conf */
 class Zone : public ConfigObject
 {
-	Q_OBJECT
+  Q_OBJECT
+  Q_CLASSINFO("IdPrefix", "zone");
 
   /** The A channels. */
   Q_PROPERTY(ChannelRefList* A READ A)


### PR DESCRIPTION
Adds a visitor pattern, preparation for implementing intermediate representations for codeplugs. This will be needed to properly implement config copying, open RTX support, etc. 