### PR TITLE
Enable APRS RX only on the APRS revert channel

### DIFF
--- a/lib/d878uv_codeplug.cc
+++ b/lib/d878uv_codeplug.cc
@@ -239,7 +239,6 @@ D878UVCodeplug::ChannelElement::fromChannelObj(const Channel *c, Context &ctx) {
       enableTXDigitalAPRS(true);
       setDigitalAPRSSystemIndex(ctx.index(dc->aprsObj()->as<GPSSystem>()));
     } else if (dc->aprsObj() && dc->aprsObj()->is<APRSSystem>()) {
-      enableRXAPRS(true);
       enableTXAnalogAPRS(true);
     }
     // Enable roaming
@@ -257,7 +256,9 @@ D878UVCodeplug::ChannelElement::fromChannelObj(const Channel *c, Context &ctx) {
     enableRXAPRS(false);
     if (nullptr != ac->aprsSystem()) {
       enableTXAnalogAPRS(true);
-      enableRXAPRS(true);
+      if (ac == ac->aprsSystem()->revertChannel()) {
+        enableRXAPRS(true);
+      }
     }
     // Apply extension settings
     if (AnytoneFMChannelExtension *ext = ac->anytoneChannelExtension()) {


### PR DESCRIPTION
Here is my proposal, of making APRS being received only on the channel which is set as the `revert` in the APRS settings tab. IMO, having it enabled always when the APRS is assigned to the channel have no sense. Another approach will be to wrap it under some config option.