### PR TITLE
Added TyT extension to set DMR squelch

### DIFF
--- a/doc/manual/codeplug/tyt/channel.xml
+++ b/doc/manual/codeplug/tyt/channel.xml
@@ -121,8 +121,8 @@
 </variablelist>
 
 <variablelist>
-  <title>Channel settings for <trademark>TyT</trademark> <productname>MD-390</productname> and 
-    <trademark>Retevis</trademark> <productname>RT8</productname></title>
+  <title>Channel settings for <trademark>TyT</trademark> <productname>MD-UV390</productname> and 
+    <trademark>Retevis</trademark> <productname>DM-2017</productname></title>
   <varlistentry>
     <term><token>killTone</token></term>
     <listitem>
@@ -161,6 +161,13 @@
     <listitem>
       <para>If DCDM is enabled, this flag specifies whether this radio is the channel leader. That 
         is, if this radio provides the clock for the time-slots.</para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term><token>dmrSquelch</token></term>
+    <listitem>
+      <para>Allows to set the squelch level for DMR channels. This prevents the LED to light all 
+      the time. The radio, however, remains silent irrespective of this setting. </para>
     </listitem>
   </varlistentry>
 </variablelist>

--- a/lib/tyt_codeplug.cc
+++ b/lib/tyt_codeplug.cc
@@ -461,7 +461,6 @@ TyTCodeplug::ChannelElement::toChannelObj(const ErrorStack &err) const {
     ex->enablePrivateCallConfirmed(privateCallConfirm());
     ex->enableDataCallConfirmed(dataCallConfirm());
     ex->enableEmergencyAlarmConfirmed(emergencyAlarmACK());
-
     // If encryption is enabled, Add commercial extension to channel if needed
     // the key will be linked later
     if ((PRIV_NONE != privacyType()) && (nullptr == dch->commercialExtension()))

--- a/lib/tyt_extensions.cc
+++ b/lib/tyt_extensions.cc
@@ -10,7 +10,7 @@ TyTChannelExtension::TyTChannelExtension(QObject *parent)
     _displayPTTId(true), _rxRefFrequency(RefFrequency::Low), _txRefFrequency(RefFrequency::Low),
     _tightSquelch(false), _compressedUDPHeader(false), _reverseBurst(true),
     _killTone(KillTone::Off), _inCallCriterion(InCallCriterion::Always), _allowInterrupt(false),
-    _dcdm(false), _dcdmLeader(false)
+    _dcdm(false), _dcdmLeader(false), _dmrSquelch(1)
 {
   // pass...
 }
@@ -131,6 +131,18 @@ TyTChannelExtension::setTXRefFrequency(RefFrequency ref) {
   if (_txRefFrequency == ref)
     return;
   _txRefFrequency = ref;
+  emit modified(this);
+}
+
+unsigned int
+TyTChannelExtension::dmrSquelch() const {
+  return _dmrSquelch;
+}
+void
+TyTChannelExtension::setDMRSquelch(unsigned int sq) {
+  if (_dmrSquelch == sq)
+    return;
+  _dmrSquelch = sq;
   emit modified(this);
 }
 

--- a/lib/tyt_extensions.hh
+++ b/lib/tyt_extensions.hh
@@ -13,6 +13,11 @@ class TyTChannelExtension: public ConfigExtension
 {
   Q_OBJECT
 
+  Q_CLASSINFO("description", "Settings for MD-390, RT8, MD-UV390, RT3S, MD-2017, RT82, DM-1701, RT84.")
+  Q_CLASSINFO("longDescription", "Device specific channel settings for TyT and Retevis devices."
+                                 "Including TyT MD-390, MD-UV390, MD-2017, Retevis RT8, RT3S and RT82"
+                                 " as well as Baofeng DM-1701.")
+
   /** The lone worker feature. */
   Q_PROPERTY(bool loneWorker READ loneWorker WRITE enableLoneWorker)
   /** The auto scan feature. */
@@ -49,11 +54,10 @@ class TyTChannelExtension: public ConfigExtension
   Q_PROPERTY(bool dcdm READ dcdm WRITE enableDCDM)
   /** If @c true, and dcdm is enabled, this radio is the leader, specifying the clock. */
   Q_PROPERTY(bool dcdmLeader READ dcdmLeader WRITE enableDCDMLeader)
-
-  Q_CLASSINFO("description", "Settings for MD-390, RT8, MD-UV390, RT3S, MD-2017, RT82, DM-1701, RT84.")
-  Q_CLASSINFO("longDescription", "Device specific channel settings for TyT and Retevis devices."
-                                 "Including TyT MD-390, MD-UV390, MD-2017, Retevis RT8, RT3S and RT82"
-                                 " as well as Baofeng DM-1701.")
+  /** The squelch level for DMR channels. */
+  Q_PROPERTY(unsigned int dmrSquelch READ dmrSquelch WRITE setDMRSquelch)
+  Q_CLASSINFO("dmrSquelchDescription", "Sets the squelch level for DMR channels. "
+              "Only applicable for MD-UV390 and MD-2017")
 
 public:
   /** Possible reference frequency settings for RX & TX. */
@@ -150,6 +154,10 @@ public:
   bool dcdmLeader() const;
   /** Enables/disables this radio to be the leader on a DCDM simplex channel. */
   void enableDCDMLeader(bool enable);
+  /** Squelch level for DMR channels. */
+  unsigned int dmrSquelch() const;
+  /** Sets the squelch-level for DMR channels. */
+  void setDMRSquelch(unsigned int sq);
 
 public:
   /*ConfigItem *allocateChild(QMetaProperty &prop, const YAML::Node &node,
@@ -195,6 +203,8 @@ protected:
   bool _dcdm;
   /** Holds the DCDM-leader flag. */
   bool _dcdmLeader;
+  /** The squelch level [0-10] for DMR channels. */
+  unsigned int _dmrSquelch;
 };
 
 

--- a/lib/uv390_codeplug.cc
+++ b/lib/uv390_codeplug.cc
@@ -189,6 +189,8 @@ UV390Codeplug::ChannelElement::toChannelObj(const ErrorStack &err) const {
     ex->enableAllowInterrupt(allowInterrupt());
     ex->enableDCDM(dualCapacityDirectMode());
     ex->enableDCDMLeader(dcdmLeader());
+    if (ch->is<DMRChannel>())
+      ex->setDMRSquelch(squelch());
   }
 
   return ch;
@@ -219,6 +221,8 @@ UV390Codeplug::ChannelElement::fromChannelObj(const Channel *chan, Context &ctx)
     enableAllowInterrupt(ex->allowInterrupt());
     enableDualCapacityDirectMode(ex->dcdm());
     enableDCDMLeader(ex->dcdmLeader());
+    if (chan->is<DMRChannel>())
+      setSquelch(ex->dmrSquelch());
   }
 }
 


### PR DESCRIPTION
Added TyT extension to set DMR squelch for TyT MD-UV390 and MD-2017 radios. Addresses #307.