### PR TITLE
Extend charset for Anytone

### DIFF
--- a/lib/anytone_codeplug.cc
+++ b/lib/anytone_codeplug.cc
@@ -565,11 +565,11 @@ AnytoneCodeplug::ChannelElement::clearEncryptionKeyIndex() {
 
 QString
 AnytoneCodeplug::ChannelElement::name() const {
-  return readASCII(0x0023, 16, 0x00);
+  return readGBK(0x0023, 16, 0x00);
 }
 void
 AnytoneCodeplug::ChannelElement::setName(const QString &name) {
-  writeASCII(0x0023, name, 16, 0x00);
+  writeGBK(0x0023, name, 16, 0x00);
 }
 
 

--- a/lib/codeplug.cc
+++ b/lib/codeplug.cc
@@ -584,16 +584,16 @@ QString
 Codeplug::Element::readGBK(unsigned offset, unsigned maxlen, uint8_t eos) const {
   QByteArray txt;
   uint8_t *ptr = (uint8_t *)(_data+offset);
-  for (unsigned i=0; (i<maxlen)&&(ptr[i])&&(eos!=ptr[i]); i++) {
+  for (unsigned i=0; (i<maxlen*2)&&(ptr[i])&&(eos!=ptr[i]); i++) {
     txt.append((ptr[i]));
   }
   return QTextCodec::codecForName("GBK")->toUnicode(txt);
 }
 void
 Codeplug::Element::writeGBK(unsigned offset, const QString &txt, unsigned maxlen, uint8_t eos) {
-  QByteArray enc = QTextCodec::codecForName("GBK")->fromUnicode(txt);
+  QByteArray enc = QTextCodec::codecForName("GBK")->fromUnicode(txt.left(maxlen));
   uint8_t *ptr = (uint8_t *)(_data+offset);
-  for (unsigned i=0; i<maxlen; i++) {
+  for (unsigned i=0; i<maxlen*2; i++) {
     if (i < unsigned(enc.length()))
       ptr[i] = enc.at(i);
     else

--- a/lib/codeplug.cc
+++ b/lib/codeplug.cc
@@ -1,6 +1,7 @@
 #include "codeplug.hh"
 #include "config.hh"
 #include <QtEndian>
+#include <QTextCodec>
 #include "logger.hh"
 #include "roamingchannel.hh"
 
@@ -579,6 +580,26 @@ Codeplug::Element::writeUnicode(unsigned offset, const QString &txt, unsigned ma
   }
 }
 
+QString
+Codeplug::Element::readGBK(unsigned offset, unsigned maxlen, uint8_t eos) const {
+  QByteArray txt;
+  uint8_t *ptr = (uint8_t *)(_data+offset);
+  for (unsigned i=0; (i<maxlen)&&(ptr[i])&&(eos!=ptr[i]); i++) {
+    txt.append((ptr[i]));
+  }
+  return QTextCodec::codecForName("GBK")->toUnicode(txt);
+}
+void
+Codeplug::Element::writeGBK(unsigned offset, const QString &txt, unsigned maxlen, uint8_t eos) {
+  QByteArray enc = QTextCodec::codecForName("GBK")->fromUnicode(txt);
+  uint8_t *ptr = (uint8_t *)(_data+offset);
+  for (unsigned i=0; i<maxlen; i++) {
+    if (i < unsigned(enc.length()))
+      ptr[i] = enc.at(i);
+    else
+      ptr[i] = eos;
+  }
+}
 
 /* ********************************************************************************************* *
  * Implementation of CodePlug::Context

--- a/lib/codeplug.hh
+++ b/lib/codeplug.hh
@@ -178,6 +178,12 @@ public:
      * The stored string gets padded with @c eos to @c maxlen. */
     void writeUnicode(unsigned offset, const QString &txt, unsigned maxlen, uint16_t eos=0x0000);
 
+    /** Reads up to @c maxlen GBK char bytes at the given byte-offset using @c eos as the string termination char. */
+    QString readGBK(unsigned offset, unsigned maxlen, uint8_t eos=0x0000) const;
+    /** Stores up to @c maxlen GBK char bytes at the given byte-offset using @c eos as the string termination char.
+     * The stored string gets padded with @c eos to @c maxlen. */
+    void writeGBK(unsigned offset, const QString &txt, unsigned maxlen, uint8_t eos=0x0000);
+
   protected:
     /** Holds the pointer to the element. */
     uint8_t *_data;

--- a/lib/codeplug.hh
+++ b/lib/codeplug.hh
@@ -178,9 +178,9 @@ public:
      * The stored string gets padded with @c eos to @c maxlen. */
     void writeUnicode(unsigned offset, const QString &txt, unsigned maxlen, uint16_t eos=0x0000);
 
-    /** Reads up to @c maxlen GBK char bytes at the given byte-offset using @c eos as the string termination char. */
+    /** Reads up to @c maxlen GBK chars at the given byte-offset using @c eos as the string termination char. */
     QString readGBK(unsigned offset, unsigned maxlen, uint8_t eos=0x0000) const;
-    /** Stores up to @c maxlen GBK char bytes at the given byte-offset using @c eos as the string termination char.
+    /** Stores up to @c maxlen GBK chars at the given byte-offset using @c eos as the string termination char.
      * The stored string gets padded with @c eos to @c maxlen. */
     void writeGBK(unsigned offset, const QString &txt, unsigned maxlen, uint8_t eos=0x0000);
 


### PR DESCRIPTION
Intro
-------

While experimenting with APRS and AT878UVII+ I've accidentally find out that  it supports much more than just ASCII characters. Further play with their CPS and scrolling through the font file, made me believe that it is the [GBK encoding](https://en.wikipedia.org/wiki/GBK_(character_encoding)).


Details
----------

GBK encodes ASCII characters on one byte, and non ASCI ones on two bytes. This could explain why some 16 characters fields are 32 bytes padded.

QT supports [GBK](https://doc.qt.io/qt-6/codec-gbk.html) through [QTextCodec](https://doc.qt.io/qt-6/qtextcodec.html). I've made my implementation on top of it and it seem to work as expected.

**This PR should give us possibility to use fancy characters like: "∮" or "№ ". It will also let something like naming "hotspot"  as "ホットスポット"** :blush: 

TODO:
----------

- [ ] Implement GBK encoding/decoding
- [ ] Implement GBK `RadioLimit`
- [ ] Use GBK in channel name as POC
- [ ] Use GBK where it is supposed to be used
- [ ] Rewrite encoding/decoding (cleanup explicit for loop)
- [ ] Fix yaml saving issue (qdmr fails to save the utf characters)
- [ ] Prepare graphic with Anytone font