### PR TITLE
Wrap c_str in QString when emiting QTextStream

### DIFF
--- a/lib/config.cc
+++ b/lib/config.cc
@@ -111,7 +111,7 @@ Config::toYAML(QTextStream &stream, const ErrorStack &err) {
   // Print YAML
   YAML::Emitter emitter;
   emitter << YAML::BeginDoc << doc << YAML::EndDoc;
-  stream << emitter.c_str();
+  stream << QString(emitter.c_str());
   return true;
 }
 


### PR DESCRIPTION
This solves the bug with multi byte UTF characters being incorrectly saved in the exported YAML files as `QTextStream::operator<<` assumes different single byte encoding.

Looks like this is the bug in QT5: https://stackoverflow.com/questions/40318671/streaming-utf-8-literals-into-qtextstream
