### PR TITLE
Adds D578UV2 support to anytone_interface.cc

### DIFF
--- a/lib/anytone_interface.cc
+++ b/lib/anytone_interface.cc
@@ -151,6 +151,8 @@ AnytoneInterface::identifier(const ErrorStack &err) {
     return RadioInfo::byID(RadioInfo::D878UVII);
   } else if ("D578UV" == _info.name) {
     return RadioInfo::byID(RadioInfo::D578UV);
+  } else if ("D578UV2" == _info.name) {
+    return RadioInfo::byID(RadioInfo::D578UV);  
   }
 
   errMsg(err) << tr("Unsupported AnyTone radio '%1', HW rev. '%2'.")


### PR DESCRIPTION
Adds support for D578UV2 by treating the radio as a D578UV, which is already supported.
I tested this on my D578UV2 and it works fine.