### PR TITLE
Remove extra % in repeaterbook load

### DIFF
--- a/src/repeaterbooksource.cc
+++ b/src/repeaterbooksource.cc
@@ -46,7 +46,7 @@ RepeaterBookSource::load(const QString &queryCall, const QGeoCoordinate &pos) {
     url = QUrl("https://www.repeaterbook.com/api/export.php");
 
   QUrlQuery query;
-  query.addQueryItem("callsign", QString("%1%").arg(call));
+  query.addQueryItem("callsign", QString("%1").arg(call));
   url.setQuery(query);
   QNetworkRequest request(url);
   request.setHeader(QNetworkRequest::UserAgentHeader,


### PR DESCRIPTION
I was trying to test out the latest changes, but all the repeaterbook lookups resulted in 0 entries. After a while I noticed the issue in the debug messages.

Original: Debug in src/repeaterbooksource.cc@54: Query RepeaterBook at https://www.repeaterbook.com/api/export.php?callsign=K7SLB%25 as 'qdmr 0.12.0 https://dm3mat.darc.de/qdmr/'

Fixed: Debug in src/repeaterbooksource.cc@54: Query RepeaterBook at https://www.repeaterbook.com/api/export.php?callsign=K7SLB as 'qdmr 0.12.0 https://dm3mat.darc.de/qdmr/'.