### PR TITLE
Include Norad IDs in satellite selection

### DIFF
--- a/lib/orbitalelementsdatabase.cc
+++ b/lib/orbitalelementsdatabase.cc
@@ -237,6 +237,20 @@ OrbitalElementsDatabase::data(const QModelIndex &index, int role) const {
   return QVariant();
 }
 
+QVariant
+OrbitalElementsDatabase::headerData(int section, Qt::Orientation orientation,
+                                int role) const {
+  if (role != Qt::DisplayRole || orientation != Qt::Horizontal)
+    return QVariant();
+
+  switch (section) {
+      case 0: return QStringLiteral("NORAD");
+      case 1: return QStringLiteral("Name");
+      case 2: return QStringLiteral("Epoch");
+  }
+
+  return QVariant();
+}
 
 unsigned
 OrbitalElementsDatabase::dbAge() const {

--- a/lib/orbitalelementsdatabase.hh
+++ b/lib/orbitalelementsdatabase.hh
@@ -149,6 +149,8 @@ public:
   int columnCount(const QModelIndex &parent = QModelIndex()) const;
   /** Returns a single cell of the database table. */
   QVariant data(const QModelIndex &index, int role) const;
+  /** Returns a single header of the database table. */
+  QVariant headerData(int section, Qt::Orientation orientation, int role) const;
 
 signals:
   /** Gets emitted once the satellite orbitals has been loaded. */

--- a/src/satelliteselectiondialog.cc
+++ b/src/satelliteselectiondialog.cc
@@ -11,7 +11,8 @@ SatelliteSelectionDialog::SatelliteSelectionDialog(OrbitalElementsDatabase *db, 
 {
   ui->setupUi(this);
   ui->satellites->setModel(_database);
-  ui->satellites->setModelColumn(1);
+  ui->satellites->hideColumn(2);
+
   SearchPopup::attach(ui->satellites);
   this->restoreGeometry(Settings().headerState(objectName()));
 }

--- a/src/satelliteselectiondialog.ui
+++ b/src/satelliteselectiondialog.ui
@@ -22,12 +22,15 @@
     </widget>
    </item>
    <item>
-    <widget class="QListView" name="satellites">
+    <widget class="QTreeView" name="satellites">
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
      </property>
-     <property name="viewMode">
-      <enum>QListView::IconMode</enum>
+     <property name="rootIsDecorated">
+      <bool>false</bool>
+     </property>
+     <property name="itemsExpandable">
+      <bool>false</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
I was testing the satellite list loading for OpenGD77 and found it a bit tricky to fill in `satellites.json`.

I started to fill in the data from the example **satellites.txt** included with OpenGD77's CPS. Because the list of satellites in qdmr is sorted by Norad ID, it was helpful to see that ID in the list.

This patch adds the Norad ID to the satellite selection dialog.

Part of the trouble was that whenever I entered a TX frequency, it was just ignored. It turned out it was because I had to use a known frequency for the satellite and the first in the list had none. This patch doesn't help there, but perhaps including a default **satellites.json** below will.

### Example starting satellites.json

```json
[
    {
        "fm_downlink": "436.795 MHz",
        "fm_uplink": "145.85 MHz",
        "fm_uplink_tone": "67.0 Hz",
        "name": "SAUDISAT 1C (SO-50)",
        "norad": 27607
    },
    {
        "aprs_downlink": "144.39 MHz",
        "aprs_uplink": "144.39 MHz",
        "beacon": "437.2 MHz",
        "fm_downlink": "437.2 MHz",
        "fm_uplink": "144.35 MHz",
        "name": "LILACSAT-2",
        "norad": 40908
    },
    {
        "fm_downlink": "145.96 MHz",
        "fm_uplink": "435.25 MHz",
        "fm_uplink_tone": "67.0 Hz",
        "name": "RADFXSAT (FOX-1B)",
        "norad": 43017
    },
    {
        "aprs_downlink": "145.9 MHz",
        "aprs_uplink": "437.5 MHz",
        "beacon": "145.9 MHz",
        "fm_downlink": "145.9 MHz",
        "fm_uplink": "437.5 MHz",
        "fm_uplink_tone": "141.3 Hz",
        "name": "DIWATA-2B",
        "norad": 43678
    },
    {
        "fm_downlink": "435.4 MHz",
        "fm_uplink": "145.85 MHz",
        "fm_uplink_tone": "67.0 Hz",
        "name": "ASRTU-1 (AO-123)",
        "norad": 61781
    },
    {
        "beacon": "436.8865 MHz",
        "fm_downlink": "436.888 MHz",
        "fm_uplink": "145.925 MHz",
        "name": "HADES-R",
        "norad": 62690
    },
    {
        "aprs_downlink": "145.825 MHz",
        "aprs_uplink": "145.825 MHz",
        "beacon": "137.6257 MHz",
        "fm_downlink": "437.8 MHz",
        "fm_uplink": "145.99 MHz",
        "fm_uplink_tone": "67.0 Hz",
        "name": "ISS (ZARYA)",
        "norad": 25544
    }
]
```