### PR TITLE
Fix OpenGD77 (UV380) codeplug encodings

### DIFF
--- a/lib/opengd77_codeplug.cc
+++ b/lib/opengd77_codeplug.cc
@@ -185,7 +185,7 @@ OpenGD77Codeplug::createChannels(Context &ctx, const ErrorStack &err) {
     else
       bank = ChannelBankElement(data(Offset::channelBank1() + (b-1)*ChannelBankElement::size(), ImageIndex::channelBank1()));
 
-    for (unsigned int i=0; i < ChannelBankElement::Limit::channelCount(); i++, c++) {
+    for (unsigned int i=0; i < ChannelBankElement::Limit::channelCount(); i++) {
       if (! bank.isEnabled(i))
         continue;
 
@@ -195,7 +195,7 @@ OpenGD77Codeplug::createChannels(Context &ctx, const ErrorStack &err) {
         return false;
       }
       ctx.config()->channelList()->add(obj);
-      ctx.add(obj, c);
+      ctx.add(obj, c++);
     }
   }
 
@@ -211,7 +211,7 @@ OpenGD77Codeplug::linkChannels(Context &ctx, const ErrorStack &err) {
     else
       bank = ChannelBankElement(data(Offset::channelBank1() + (b-1)*ChannelBankElement::size(), ImageIndex::channelBank1()));
 
-    for (unsigned int i=0; i < ChannelBankElement::Limit::channelCount(); i++, c++) {
+    for (unsigned int i=0; i < ChannelBankElement::Limit::channelCount(); i++) {
       if (! bank.isEnabled(i))
         continue;
 
@@ -221,6 +221,7 @@ OpenGD77Codeplug::linkChannels(Context &ctx, const ErrorStack &err) {
                     << "' from index " << i << " in bank " << b << ".";
         return false;
       }
+      c++;
     }
   }
 

--- a/lib/opengd77_extension.hh
+++ b/lib/opengd77_extension.hh
@@ -130,12 +130,11 @@ class OpenGD77ContactExtension: public ConfigExtension
               "channel for that contact that only differs in the time slot.")
 
 public:
-  /** Possible values for the time-slot override option.
-   * Encoded values are correct for firmware 2022-02-28 (0118581D) to 2025-03-23 (1bd23ea). */
+  /** Possible modes of time slot override. */
   enum class TimeSlotOverride {
-    None = 0x01,                  ///< Do not override time-slot of channel.
-    TS1  = 0x00,                  ///< Force time-slot to TS1.
-    TS2  = 0x02                   ///< Force time-slot to TS2.
+    None, ///< Do not override time slot.
+    TS1,  ///< Override with time slot 1.
+    TS2   ///< Override with time slot 2.
   };
   Q_ENUM(TimeSlotOverride)
 

--- a/lib/opengd77base_codeplug.cc
+++ b/lib/opengd77base_codeplug.cc
@@ -591,7 +591,6 @@ OpenGD77BaseCodeplug::ChannelElement::link(Channel *c, Context &ctx, const Error
       dc->setGroupListObj(ctx.get<RXGroupList>(groupListIndex()));
     if (hasTXContact() && ctx.has<DMRContact>(txContactIndex()))
       dc->setTXContactObj(ctx.get<DMRContact>(txContactIndex()));
-
     // Testing dmrId() == 0 fixes a bug in the OpenGD77 firmware. May change in future.
     if (hasDMRId() && (0 != dmrId())) {
       logDebug() << "Channel '" << c->name() << "' overrides default DMR id with "
@@ -1772,7 +1771,7 @@ OpenGD77BaseCodeplug::ContactElement::clear() {
   setName("");
   setNumber(0);
   setType(DMRContact::GroupCall);
-  setTimeSlotOverride(OpenGD77ContactExtension::TimeSlotOverride::None);
+  setTimeSlotOverride(TimeSlotOverride::None);
 }
 
 
@@ -1825,12 +1824,12 @@ OpenGD77BaseCodeplug::ContactElement::setType(DMRContact::Type type) {
 }
 
 
-OpenGD77ContactExtension::TimeSlotOverride
+OpenGD77BaseCodeplug::ContactElement::TimeSlotOverride
 OpenGD77BaseCodeplug::ContactElement::timeSlotOverride() const {
-  return (OpenGD77ContactExtension::TimeSlotOverride)getUInt8(Offset::timeSlotOverride());
+  return (TimeSlotOverride)getUInt8(Offset::timeSlotOverride());
 }
 void
-OpenGD77BaseCodeplug::ContactElement::setTimeSlotOverride(OpenGD77ContactExtension::TimeSlotOverride ts) {
+OpenGD77BaseCodeplug::ContactElement::setTimeSlotOverride(TimeSlotOverride ts) {
   setUInt8(Offset::timeSlotOverride(), (unsigned int) ts);
 }
 
@@ -1846,7 +1845,20 @@ OpenGD77BaseCodeplug::ContactElement::decode(Context &ctx, const ErrorStack &err
   auto contact = new DMRContact(type(), name(), number(), false);
   contact->setOpenGD77ContactExtension(new OpenGD77ContactExtension());
 
-  contact->openGD77ContactExtension()->setTimeSlotOverride(timeSlotOverride());
+  switch (timeSlotOverride()) {
+  case TimeSlotOverride::None:
+    contact->openGD77ContactExtension()->setTimeSlotOverride(
+          OpenGD77ContactExtension::TimeSlotOverride::None);
+    break;
+  case TimeSlotOverride::TS1:
+    contact->openGD77ContactExtension()->setTimeSlotOverride(
+          OpenGD77ContactExtension::TimeSlotOverride::TS1);
+    break;
+  case TimeSlotOverride::TS2:
+    contact->openGD77ContactExtension()->setTimeSlotOverride(
+          OpenGD77ContactExtension::TimeSlotOverride::TS2);
+    break;
+  }
 
   return contact;
 }
@@ -1861,7 +1873,17 @@ OpenGD77BaseCodeplug::ContactElement::encode(const DMRContact *cont, Context &ct
   if (nullptr == cont->openGD77ContactExtension())
     return true;
 
-  setTimeSlotOverride(cont->openGD77ContactExtension()->timeSlotOverride());
+  switch (cont->openGD77ContactExtension()->timeSlotOverride()) {
+  case OpenGD77ContactExtension::TimeSlotOverride::None:
+    setTimeSlotOverride(TimeSlotOverride::None);
+    break;
+  case OpenGD77ContactExtension::TimeSlotOverride::TS1:
+    setTimeSlotOverride(TimeSlotOverride::TS1);
+    break;
+  case OpenGD77ContactExtension::TimeSlotOverride::TS2:
+    setTimeSlotOverride(TimeSlotOverride::TS2);
+    break;
+  }
 
   return true;
 }

--- a/lib/opengd77base_codeplug.hh
+++ b/lib/opengd77base_codeplug.hh
@@ -921,6 +921,15 @@ public:
   /** Implements digital contacts in OpenGD77 codeplugs. */
   class ContactElement: public Element
   {
+  public:
+    /** Possible values for the time-slot override option.
+     * Encoded values are correct for firmware 2022-02-28 (0118581D) to 2025-03-23 (1bd23ea). */
+    enum class TimeSlotOverride {
+      None = 0x01,                  ///< Do not override time-slot of channel.
+      TS1  = 0x00,                  ///< Force time-slot to TS1.
+      TS2  = 0x02                   ///< Force time-slot to TS2.
+    };
+
   protected:
     /** Hidden constructor. */
     ContactElement(uint8_t *ptr, unsigned size);
@@ -956,9 +965,9 @@ public:
     virtual void setType(DMRContact::Type type);
 
     /** Returns the time slot override of the contact. */
-    virtual OpenGD77ContactExtension::TimeSlotOverride timeSlotOverride() const;
+    virtual TimeSlotOverride timeSlotOverride() const;
     /** Sets the time slot override. */
-    virtual void setTimeSlotOverride(OpenGD77ContactExtension::TimeSlotOverride ts);
+    virtual void setTimeSlotOverride(TimeSlotOverride ts);
 
     /** Constructs a @c DigitalContact instance from this codeplug contact. */
     virtual DMRContact *decode(Context &ctx, const ErrorStack &err=ErrorStack()) const;

--- a/lib/openuv380_codeplug.cc
+++ b/lib/openuv380_codeplug.cc
@@ -186,7 +186,7 @@ OpenUV380Codeplug::createChannels(Context &ctx, const ErrorStack &err) {
     else
       bank = ChannelBankElement(data(Offset::channelBank1() + (b-1)*ChannelBankElement::size(), ImageIndex::channelBank1()));
 
-    for (unsigned int i=0; i<ChannelBankElement::Limit::channelCount(); i++, c++) {
+    for (unsigned int i=0; i < ChannelBankElement::Limit::channelCount(); i++) {
       if (! bank.isEnabled(i))
         continue;
 
@@ -196,7 +196,7 @@ OpenUV380Codeplug::createChannels(Context &ctx, const ErrorStack &err) {
         return false;
       }
       ctx.config()->channelList()->add(obj);
-      ctx.add(obj, c);
+      ctx.add(obj, c++);
     }
   }
 
@@ -212,7 +212,7 @@ OpenUV380Codeplug::linkChannels(Context &ctx, const ErrorStack &err) {
     else
       bank = ChannelBankElement(data(Offset::channelBank1() + (b-1)*ChannelBankElement::size(), ImageIndex::channelBank1()));
 
-    for (unsigned int i=0; i<ChannelBankElement::Limit::channelCount(); i++, c++) {
+    for (unsigned int i=0; i < ChannelBankElement::Limit::channelCount(); i++) {
       if (! bank.isEnabled(i))
         continue;
 
@@ -226,6 +226,7 @@ OpenUV380Codeplug::linkChannels(Context &ctx, const ErrorStack &err) {
                     << "' from index " << i << " in bank " << b << ".";
         return false;
       }
+      c++;
     }
   }
 


### PR DESCRIPTION
This fixes two issues with OpenGD77 codeplugs:

1. There was an off-by-one error in the UV380 linkChannels() function.

2. The values written to timeSlotOverride for TS1 and "None" were swapped. This seemed like it was two to the confusion of having two enums for the override. The one with correct values was used for the UI and the one with "naive" values was used for the codeplug. TS1 should be 0x00 and None should be 0x01. I thought the best approach was to only have one enum with the correct codeplug values, since it doesn't matter what the enum values are for the UI.