### PR TITLE
Fix Flatpak id and device access

### DIFF
--- a/de.darc.dm3mat.qdmr.yaml
+++ b/de.darc.dm3mat.qdmr.yaml
@@ -1,4 +1,4 @@
-app-id: io.github.hmatuschek.qdmr
+app-id: de.darc.dm3mat.qdmr
 runtime: org.kde.Platform
 runtime-version: '5.15-24.08'
 sdk: org.kde.Sdk
@@ -6,7 +6,7 @@ command: qdmr
 rename-desktop-file: qdmr.desktop
 rename-icon: qdmr
 finish-args:
-  - --device=dri
+  - --device=all
   - --share=network
   - --share=ipc
   - --socket=fallback-x11


### PR DESCRIPTION
Oops, I did not notice that the app id does not match the actual AppStream metadata one.

Also, add the "all" device access to make the QDMR Flatpak actually see the devices.