### PR TITLE
dmrconf detect: report detected radio

### DIFF
--- a/cli/detect.cc
+++ b/cli/detect.cc
@@ -16,8 +16,9 @@ int detect(QCommandLineParser &parser, QCoreApplication &app) {
     return -1;
   }
 
-  logInfo() << "Found: '" << radio->name() << "'.";
-  delete  radio;
+  QTextStream out(stdout);
+  out << "Found: " << radio->name() << Qt::endl;
+  delete radio;
 
   return 0;
 }


### PR DESCRIPTION
Use a normal text stream connected to stdout to report the detected radio, instead of going through the logging infrastructure.  This means the detected radio is reported to the user no matter what the log level is set to.