### PR TITLE
Fix build on macOS

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -163,7 +163,7 @@ set_target_properties(libdmrconf PROPERTIES
   SOVERSION "${PROJECT_VERSION_MAJOR}")
 
 target_link_libraries(libdmrconf PRIVATE Qt6::Core Qt6::SerialPort Qt6::Positioning Qt6::Network
-  ${LIBUSB_1_LIBRARIES} ${YAMLCPP_LIBRARIES})
+  ${LIBUSB_1_LIBRARIES} ${YAMLCPP_LIBRARIES} ${ADDITIONAL_LIBS})
 
 install(TARGETS libdmrconf DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 


### PR DESCRIPTION
I was trying to build devel branch to see status of Qt6 support and hit a link error on macOS:
```
[ 39%] Linking CXX shared library libdmrconf.dylib
cd /private/tmp/qdmr-20250828-85410-b8tnvm/build/lib && /opt/homebrew/opt/cmake/bin/cmake -E cmake_link_script CMakeFiles/libdmrconf.dir/link.txt --verbose=1
Undefined symbols for architecture arm64:
  "_CFDictionaryCreateMutable", referenced from:
      HIDevice::HIDevice(USBDeviceDescriptor const&, ErrorStack const&, QObject*) in hid_macos.cc.o
```

Looks like a regression from Qt6 PR with removal of `CORE_LIBS` in https://github.com/hmatuschek/qdmr/commit/801401eaec4120ec549c8ebea9d196eabef49519