### PR TITLE
Fix typo in udev rules

### DIFF
--- a/dist/99-qdmr.rules
+++ b/dist/99-qdmr.rules
@@ -1,4 +1,4 @@
-# Radioddity RD-73
+# Radioddity GD-73
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1206", ATTRS{idProduct}=="0227", MODE="660", GROUP="dialout"
 
 # TYT MD-UV380


### PR DESCRIPTION
Radioddity RD-73 -> Radioddity GD-73

(https://www.radioddity.com/products/radioddity-gd-73a-e)

/cc @hmatuschek

Also, it looks like that there is no such radio as Baofeng TD-5R. Did you mean DM-5R?