### PR TITLE
Fixes #679 Theme updates when system switches to/from light/dark

### DIFF
--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -3,6 +3,7 @@
 #include <QProgressBar>
 #include <QCloseEvent>
 #include <QMessageBox>
+#include <QStyleHints>
 
 #include "settings.hh"
 #include "logger.hh"
@@ -46,6 +47,11 @@ MainWindow::MainWindow(Config *config, QWidget *parent)
   ui->actionRefreshOrbitalElements->setIcon(QIcon::fromTheme("document-download"));
   ui->actionWriteSatellites->setIcon(QIcon::fromTheme("device-write-satellites"));
   ui->actionEditSatellites->setIcon(QIcon::fromTheme("edit-satellites"));
+
+  connect(qApp->styleHints(), &QStyleHints::colorSchemeChanged, this, [=](Qt::ColorScheme scheme) {
+      bool isDarkTheme = scheme == Qt::ColorScheme::Dark ? true : false;
+      QIcon::setThemeName(isDarkTheme ? "dark" : "light");
+  });
 
   connect(ui->actionNewCodeplug, SIGNAL(triggered()), app, SLOT(newCodeplug()));
   connect(ui->actionOpenCodeplug, SIGNAL(triggered()), app, SLOT(loadCodeplug()));


### PR DESCRIPTION
This fixes the problem that you would need to relaunch the app if your desktop was changed from dark to light mode or vice versa for the icons to update. This change should make it automatic.

Tested on macOS 15.6.1 Sequoia 