### PR TITLE
Add BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,137 @@
+# Building `qdmr`
+
+## Overview
+
+`qdmr` is a Qt6-based application. This document provides instructions to build the project and details the required dependencies for Ubuntu/Debian, Fedora, Arch Linux, and macOS (with Homebrew).
+
+---
+
+## Dependencies
+
+The following dependencies are required:
+
+- `qt6-base-dev`
+- `qt6-tools-dev`
+- `qt6-tools-dev-tools`
+- `qt6-positioning-dev`
+- `qt6-serialport-dev`
+- `libyaml-cpp-dev`
+- `librsvg2-bin`
+- `libusb-1.0-0-dev`
+
+Equivalent packages are listed for Fedora, Arch Linux, and macOS.
+
+---
+
+## 1. Ubuntu / Debian
+
+### **Install Dependencies**
+
+```sh
+sudo apt update
+sudo apt install -y \
+  qt6-base-dev qt6-tools-dev qt6-tools-dev-tools \
+  qt6-positioning-dev qt6-serialport-dev \
+  libyaml-cpp-dev librsvg2-bin libusb-1.0-0-dev \
+  build-essential cmake git
+```
+
+---
+
+## 2. Fedora
+
+### **Install Dependencies**
+
+```sh
+sudo dnf install -y \
+  qt6-qtbase-devel qt6-qttools-devel qt6-qtpositioning-devel qt6-qtserialport-devel \
+  yaml-cpp-devel librsvg2-tools libusb1-devel \
+  make gcc-c++ cmake git
+```
+
+---
+
+## 3. Arch Linux
+
+### **Install Dependencies**
+
+```sh
+sudo pacman -S --needed \
+  qt6-base qt6-tools qt6-positioning qt6-serialport \
+  yaml-cpp librsvg libusb cmake git base-devel
+```
+
+---
+
+## 4. macOS (Homebrew)
+
+### **Install Dependencies**
+
+```sh
+brew install \
+  qt@6 yaml-cpp librsvg libusb cmake git
+```
+
+> **Note:** You may need to set environment variables for Qt6 tools if Homebrew does not symlink them into your PATH:
+>
+> ```sh
+> export PATH="/opt/homebrew/opt/qt@6/bin:$PATH"
+> export LDFLAGS="-L/opt/homebrew/opt/qt@6/lib"
+> export CPPFLAGS="-I/opt/homebrew/opt/qt@6/include"
+> ```
+
+---
+
+## Build Instructions (All Platforms)
+
+1. **Clone the repository**
+
+   ```sh
+   git clone https://github.com/billbonney/qdmr.git
+   cd qdmr
+   ```
+
+2. **Create a build directory**
+
+   ```sh
+   mkdir build
+   cd build
+   ```
+
+3. **Configure the project**
+
+   On most systems, use CMake with Qt6:
+   ```sh
+   cmake .. -DCMAKE_PREFIX_PATH=/path/to/Qt6 # Often not needed if qt6 is in your PATH
+   ```
+
+   > On macOS, you may need to help CMake find Qt6:
+   > ```sh
+   > cmake .. -DCMAKE_PREFIX_PATH=$(brew --prefix qt@6)
+   > ```
+
+4. **Build the project**
+
+   ```sh
+   cmake --build .
+   ```
+
+5. **(Optional) Run the application**
+
+   ```sh
+   ./qdmr
+   ```
+
+---
+
+## Troubleshooting
+
+- **Missing Packages:** Ensure all dependencies are installed as per your OS section.
+- **CMake Can't Find Qt6:** Double-check your `PATH`, `CMAKE_PREFIX_PATH`, and Qt6 installation.
+- **Permission Errors:** Try using `sudo` if needed for installation steps, but not for building the project.
+
+---
+
+## License
+
+See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Adds BUILD.md file to help quickly get a build up and running with the correct dependencies for Qt6.

Probably needs a section to add the rules.d file and restart commands(?)

Tested
[] macOS 15.6.3
[] xubuntu 25.04 Plucky Penguin
[] Arch Linux
[] Fedora