### PR TITLE
Do not hardcode screenshot size in AppStream metadata

### DIFF
--- a/dist/de.darc.dm3mat.qdmr.metainfo.xml
+++ b/dist/de.darc.dm3mat.qdmr.metainfo.xml
@@ -26,7 +26,7 @@
 
   <screenshots>
     <screenshot type="default">
-      <image width="1409" height="620">https://raw.githubusercontent.com/hmatuschek/qdmr/master/doc/fig/qdmr-channels.png</image>
+      <image>https://raw.githubusercontent.com/hmatuschek/qdmr/master/doc/fig/qdmr-channels.png</image>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
This is bad practice, especially when linking a screenshot from the master branch.