### PR TITLE
Fix desktop file

### DIFF
--- a/dist/qdmr.desktop.in
+++ b/dist/qdmr.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=QDMR
-GenericName=Codeplug programming software for DMR radios.
-Comment=A universal codeplug programming software for DMR radios.
+GenericName=Codeplug programming software
+Comment=A universal codeplug programming software for DMR radios
 Exec=qdmr
 Icon=qdmr
 Type=Application


### PR DESCRIPTION
- Remove the trailing dot at the end of the comment
- Fix generic app name that should not be too long