### PR TITLE
Input Improvement: Update frequency input matching

### DIFF
--- a/lib/frequency.cc
+++ b/lib/frequency.cc
@@ -3,6 +3,11 @@
 #include <QRegularExpression>
 
 
+inline const QString HzString = QStringLiteral("Hz");
+inline const QString KHzString = QStringLiteral("MHz");
+inline const QString MHzString = QStringLiteral("MHz");
+inline const QString GHzString = QStringLiteral("GHz");
+
 /* ******************************************************************************************** *
  * Implementation of FrequencyBase
  * ******************************************************************************************** */
@@ -19,46 +24,54 @@ FrequencyBase::operator =(const FrequencyBase &other) {
 }
 
 QString
-FrequencyBase::format(Format f) const {
-  switch (f) {
-  case Format::Automatic:
-    if (10000LL > std::abs(_frequency))
-      return format(Format::Hz);
-    else if (10000000LL > std::abs(_frequency))
-      return format(Format::kHz);
-    else if (10000000000LL > std::abs(_frequency))
-      return format(Format::MHz);
-    return format(Format::GHz);
-  case Format::Hz:
+FrequencyBase::format(Unit unit) const {
+  switch (unit) {
+  case Unit::Auto:
+    if (10000LL > std::abs(_frequency)) {
+      return format(Unit::Hz);
+    } else if (10000000LL > std::abs(_frequency)) {
+      return format(Unit::kHz);
+    } else if (10000000000LL > std::abs(_frequency)) {
+      return format(Unit::MHz);
+    }
+    return format(Unit::GHz);
+
+  case Unit::Hz:
     return QString("%1 Hz").arg(inHz());
-  case Format::kHz:
+
+  case Unit::kHz:
     return QString("%1 kHz").arg(inkHz(), 0, 'g', 6);
-  case Format::MHz:
+
+  case Unit::MHz:
     return QString("%1 MHz").arg(inMHz(), 0, 'g', 9);
-  case Format::GHz:
+
+  case Unit::GHz:
     return QString("%1 GHz").arg(inGHz(), 0, 'g', 12);
+
   }
   return "";
 }
 
 bool
-FrequencyBase::parse(const QString &value) {
-  QRegularExpression re(R"(\s*(\+|-)?\s*([0-9]+)(?:\.([0-9]*)|)\s*([kMG]?Hz|)\s*)");
+FrequencyBase::parse(const QString &value, Qt::CaseSensitivity caseSensitivity) {
+
+  QRegularExpression::PatternOption patternOption = caseSensitivity == Qt::CaseInsensitive
+    ? QRegularExpression::PatternOption::CaseInsensitiveOption : QRegularExpression::PatternOption::NoPatternOption;
+
+  static QRegularExpression re(R"(\s*(\+|-)?\s*([0-9]+)(?:\.([0-9]*)|)\s*([kMG]?)(Hz)?\s*)", patternOption);
   QRegularExpressionMatch match = re.match(value);
-  if (! match.hasMatch())
+
+  if (!match.hasMatch())
     return false;
 
   bool isNegative = ("-" == match.captured(1));
-  bool hasUnit = match.capturedLength(4);
-  QString unit = match.captured(4);
+  auto unit = unitFromString(match.captured(4));
   QString decimals = match.captured(3);
   QString leading = match.captured(2);
   _frequency = leading.toUInt();
 
-  if ("Hz" == unit)
-    return true;
-
-  if ("kHz" == unit) {
+  switch (unit)  {
+  case Unit::kHz: {
     _frequency *= 1000ULL;
     unsigned long long factor = 100ULL;
     for (int i=0; i<std::min((qsizetype)3, decimals.size()); i++) {
@@ -68,7 +81,9 @@ FrequencyBase::parse(const QString &value) {
     // Rounding to proper Hz
     if ((decimals.size()>3) && (decimals[3].digitValue()>=5))
       _frequency += 1;
-  } else if (("MHz"==unit) || (!hasUnit)) {
+  }
+  break;
+  case Unit::MHz: {
     _frequency *= 1000000ULL;
     unsigned long long factor = 100000ULL;
     for (int i=0; i<std::min((qsizetype)6, decimals.size()); i++) {
@@ -78,7 +93,9 @@ FrequencyBase::parse(const QString &value) {
     // Rounding to proper Hz
     if ((decimals.size()>6) && (decimals[6].digitValue()>=5))
       _frequency += 1;
-  } else if ("GHz"==unit) {
+  }
+  break;
+  case Unit::GHz: {
     _frequency *= 1000000000ULL;
     unsigned long long factor = 100000000;
     for (int i=0; i<std::min((qsizetype)9, decimals.size()); i++) {
@@ -89,13 +106,73 @@ FrequencyBase::parse(const QString &value) {
     if ((decimals.size()>9) && (decimals[9].digitValue()>=5))
       _frequency+=1;
   }
+  break;
+  case Unit::Hz:
+  default:
+    ; // Do Nothing
+  }
 
   if (isNegative)
-    _frequency *= -1;
+    _frequency = -_frequency;
 
   return true;
 }
 
+FrequencyBase::Unit FrequencyBase::unit() const {
+  qint64 absFreq = std::abs(_frequency);
+  if (absFreq >= 1000000000LL)
+    return Unit::GHz;
+  else if (absFreq >= 1000000LL)
+    return Unit::MHz;
+  else if (absFreq >= 1000LL)
+    return Unit::kHz;
+  else
+    return Unit::Hz;
+}
+
+FrequencyBase::Unit FrequencyBase::unitFromString(const QString& input) const {
+  Unit result;
+  if (input.length() == 0) {
+    return Unit::MHz;
+  }
+
+  auto multiplier = input[0].toLower();
+
+  if (multiplier == 'k') {
+    result = Unit::kHz;
+  } else if (multiplier == 'm') {
+    result = Unit::MHz;
+  } else if (multiplier == 'g') {
+    result = Unit::GHz;
+  } else {
+    result = Unit::Hz;
+  }
+  return result;
+}
+
+bool FrequencyBase::isMultipleOf(Unit u) const {
+  switch(u) {
+  case Unit::kHz: return (_frequency % 1000LL) == 0;
+  case Unit::MHz: return (_frequency % 1000000LL) == 0;
+  case Unit::GHz: return (_frequency % 1000000000LL) == 0;
+  case Unit::Hz:
+    //fallthrough
+  default: return true;
+  }
+  return false; // Unreachable
+}
+
+QString FrequencyBase::unitName(Unit unit) {
+  switch(unit) {
+  case Unit::kHz: return KHzString;
+  case Unit::MHz: return MHzString;
+  case Unit::GHz: return GHzString;
+  case Unit::Hz:
+    //fallthrough
+  default: return HzString;
+  }
+  return QString();
+}
 
 
 /* ******************************************************************************************** *
@@ -167,15 +244,6 @@ Frequency::operator+(const FrequencyOffset &offset) const {
 FrequencyOffset
 Frequency::operator-(const Frequency &other) const {
   return FrequencyOffset(_frequency - other._frequency);
-}
-
-bool
-Frequency::parse(const QString &value) {
-  QRegularExpression re(R"(\s*([0-9]+)(?:\.([0-9]*)|)\s*([kMG]?Hz|)\s*)");
-  QRegularExpressionMatch match = re.match(value);
-  if (! match.hasMatch())
-    return false;
-  return FrequencyBase::parse(value);
 }
 
 Frequency

--- a/lib/frequency.hh
+++ b/lib/frequency.hh
@@ -13,10 +13,8 @@
 struct FrequencyBase
 {
 public:
-  /** Possible formatting hints. */
-  enum class Format {
-    Automatic, Hz, kHz, MHz, GHz
-  };
+  /** Frequency units. */
+  enum class Unit { Auto, Hz, kHz, MHz, GHz };
 
 protected:
   /** Hidden constructor from offset in Hz. */
@@ -37,14 +35,26 @@ public:
   inline bool isZero() const { return 0 == _frequency; }
 
   /** Format the frequency. */
-  QString format(Format f=Format::Automatic) const;
+  QString format(Unit unit = Unit::Auto) const;
   /** Parses a frequency. */
-  bool parse(const QString &value);
+  bool parse(const QString &value, Qt::CaseSensitivity caseSensitivity = Qt::CaseInsensitive);
 
   inline long long inHz() const { return _frequency; }             ///< Unit conversion.
   inline double inkHz() const { return double(_frequency)/1e3; }   ///< Unit conversion.
   inline double inMHz() const { return double(_frequency)/1e6; }   ///< Unit conversion.
   inline double inGHz() const { return double(_frequency)/1e9; }   ///< Unit conversion.
+
+  /** Returns the most appropriate unit for the frequency value. */
+  Unit unit() const;
+
+  /** Returns unit as type base on string input */
+  Unit unitFromString(const QString& input) const;
+
+  /** Checks if frequency is a multiple of unit. */
+  bool isMultipleOf(Unit unit) const;
+
+  /** Helper for string conversion of unit. */
+  static QString unitName(Unit unit);
 
 protected:
   /** The actual frequency in Hz. */
@@ -135,8 +145,6 @@ public:
   Frequency &operator+=(const FrequencyOffset &offset);
   FrequencyOffset operator-(const Frequency &other) const;    ///< Frequency arithmetic.
 
-  /** Parses a frequency. */
-  bool parse(const QString &value);
   /** Pareses a frequency. */
   static Frequency fromString(const QString &freq);
 
@@ -229,7 +237,7 @@ namespace YAML
     static bool decode(const Node& node, Frequency& rhs) {
       if (! node.IsScalar())
         return false;
-      return rhs.parse(QString::fromStdString(node.as<std::string>()));
+      return rhs.parse(QString::fromStdString(node.as<std::string>()), Qt::CaseSensitive);
     }
   };
 }

--- a/src/analogchanneldialog.cc
+++ b/src/analogchanneldialog.cc
@@ -84,8 +84,8 @@ AnalogChannelDialog::construct() {
   voxDefault->setChecked(true); voxValue->setValue(0); voxValue->setEnabled(false);
 
   channelName->setText(_myChannel->name());
-  rxFrequency->setText(_myChannel->rxFrequency().format(Frequency::Format::MHz));
-  txFrequency->setText(_myChannel->txFrequency().format(Frequency::Format::MHz));
+  rxFrequency->setText(_myChannel->rxFrequency().format(Frequency::Unit::MHz));
+  txFrequency->setText(_myChannel->txFrequency().format(Frequency::Unit::MHz));
 
   offsetComboBox->addItem(QIcon::fromTheme("symbol-none"), "");
   offsetComboBox->setItemData(0, tr("No offset"), Qt::ToolTipRole);

--- a/src/configitemwrapper.cc
+++ b/src/configitemwrapper.cc
@@ -281,9 +281,9 @@ ChannelListWrapper::data(const QModelIndex &index, int role) const {
   case 1:
     return channel->name();
   case 2:
-    return channel->rxFrequency().format(Frequency::Format::MHz);
+    return channel->rxFrequency().format(Frequency::Unit::MHz);
   case 3:
-    return channel->txFrequency().format(Frequency::Format::MHz);
+    return channel->txFrequency().format(Frequency::Unit::MHz);
   case 4:
     if (channel->defaultPower())
       return tr("[Default]");
@@ -533,8 +533,8 @@ RoamingChannelListWrapper::data(const QModelIndex &index, int role) const {
   // Dispatch by column
   switch (index.column()) {
   case 0: return ch->name();
-  case 1: return ch->rxFrequency().format(Frequency::Format::MHz);
-  case 2: return ch->txFrequency().format(Frequency::Format::MHz);
+  case 1: return ch->rxFrequency().format(Frequency::Unit::MHz);
+  case 2: return ch->txFrequency().format(Frequency::Unit::MHz);
   case 3:
     if (ch->colorCodeOverridden())
       return ch->colorCode();

--- a/src/digitalchanneldialog.cc
+++ b/src/digitalchanneldialog.cc
@@ -110,8 +110,8 @@ DigitalChannelDialog::construct() {
   voxDefault->setChecked(true); voxValue->setValue(0); voxValue->setEnabled(false);
 
   channelName->setText(_myChannel->name());
-  rxFrequency->setText(_myChannel->rxFrequency().format(Frequency::Format::MHz));
-  txFrequency->setText(_myChannel->txFrequency().format(Frequency::Format::MHz));
+  rxFrequency->setText(_myChannel->rxFrequency().format(Frequency::Unit::MHz));
+  txFrequency->setText(_myChannel->txFrequency().format(Frequency::Unit::MHz));
 
   offsetComboBox->addItem(QIcon::fromTheme("symbol-none"), "");
   offsetComboBox->setItemData(0, tr("No offset"), Qt::ToolTipRole);

--- a/src/roamingchanneldialog.cc
+++ b/src/roamingchanneldialog.cc
@@ -40,9 +40,9 @@ RoamingChannelDialog::construct() {
 
   ui->name->setText(_myChannel->name());
   ui->rxFrequency->setValidator(new QDoubleValidator(0,500,5));
-  ui->rxFrequency->setText(_myChannel->rxFrequency().format(Frequency::Format::MHz));
+  ui->rxFrequency->setText(_myChannel->rxFrequency().format(Frequency::Unit::MHz));
   ui->txFrequency->setValidator(new QDoubleValidator(0,500,5));
-  ui->txFrequency->setText(_myChannel->txFrequency().format(Frequency::Format::MHz));
+  ui->txFrequency->setText(_myChannel->txFrequency().format(Frequency::Unit::MHz));
   ui->timeSlot->addItem(tr("TS 1"), QVariant::fromValue(DMRChannel::TimeSlot::TS1));
   ui->timeSlot->addItem(tr("TS 2"), QVariant::fromValue(DMRChannel::TimeSlot::TS2));
   ui->timeSlot->setCurrentIndex(


### PR DESCRIPTION
Will match uppper and lower case frequency multipliers. e.g MHz|mhz|M|m -> MHz etc..

This allow anycase to be used, Examples.
100GHz to be entered as 100G or 100g 
100MHz to be entered as 100M or 100m
100kHz to be entered as 100K or 100k

NOTE: Config files are still cases senstive and require the Hz ie GHz, MHz, kHz, Hz

I've added some helper methods will be used to detect frequency scalar toe enable a UI feature to determin if repeater offset is +'ve -'ve and has 600kHz or 5Mhz shifts