### PR TITLE
Fix D578 issues with display colors

### DIFF
--- a/lib/d578uv_codeplug.cc
+++ b/lib/d578uv_codeplug.cc
@@ -1340,11 +1340,11 @@ D578UVCodeplug::GeneralSettingsElement::setAutoRoamPeriod(Interval intv) {
 
 AnytoneDisplaySettingsExtension::Color
 D578UVCodeplug::GeneralSettingsElement::callDisplayColor() const {
-  return (AnytoneDisplaySettingsExtension::Color)getUInt8(Offset::callColor());
+  return NameColor::decode(getUInt8(Offset::callColor()));
 }
 void
 D578UVCodeplug::GeneralSettingsElement::setCallDisplayColor(AnytoneDisplaySettingsExtension::Color color) {
-  setUInt8(Offset::callColor(), (unsigned)color);
+  setUInt8(Offset::callColor(), NameColor::encode(color));
 }
 
 bool
@@ -1400,20 +1400,20 @@ D578UVCodeplug::GeneralSettingsElement::setAutoRoamDelay(Interval intv) {
 
 AnytoneDisplaySettingsExtension::Color
 D578UVCodeplug::GeneralSettingsElement::standbyTextColor() const {
-  return (AnytoneDisplaySettingsExtension::Color)getUInt8(Offset::standbyTextColor());
+  return TextColor::decode(getUInt8(Offset::standbyTextColor()));
 }
 void
 D578UVCodeplug::GeneralSettingsElement::setStandbyTextColor(AnytoneDisplaySettingsExtension::Color color) {
-  setUInt8(Offset::standbyTextColor(), (unsigned)color);
+  setUInt8(Offset::standbyTextColor(), TextColor::encode(color));
 }
 
 AnytoneDisplaySettingsExtension::Color
 D578UVCodeplug::GeneralSettingsElement::standbyBackgroundColor() const {
-  return (AnytoneDisplaySettingsExtension::Color)getUInt8(Offset::standbyBackground());
+  return TextColor::decode(getUInt8(Offset::standbyBackground()));
 }
 void
 D578UVCodeplug::GeneralSettingsElement::setStandbyBackgroundColor(AnytoneDisplaySettingsExtension::Color color) {
-  setUInt8(Offset::standbyBackground(), (unsigned)color);
+  setUInt8(Offset::standbyBackground(), TextColor::encode(color));
 }
 
 bool
@@ -1578,11 +1578,11 @@ D578UVCodeplug::GeneralSettingsElement::enableKeepLastCaller(bool enable) {
 
 AnytoneDisplaySettingsExtension::Color
 D578UVCodeplug::GeneralSettingsElement::channelNameColor() const {
-  return (AnytoneDisplaySettingsExtension::Color) getUInt8(Offset::channelNameColor());
+  return NameColor::decode(getUInt8(Offset::channelNameColor()));
 }
 void
 D578UVCodeplug::GeneralSettingsElement::setChannelNameColor(AnytoneDisplaySettingsExtension::Color color) {
-  setUInt8(Offset::channelNameColor(), (unsigned)color);
+  setUInt8(Offset::channelNameColor(), NameColor::encode(color));
 }
 
 bool
@@ -1910,7 +1910,7 @@ D578UVCodeplug::GeneralSettingsElement::fromConfig(const Flags &flags, Context &
   enableShowCurrentContact(ext->displaySettings()->showContact());
   setStandbyTextColor(ext->displaySettings()->standbyTextColor());
   enableShowLastHeard(ext->displaySettings()->showLastHeardEnabled());
-  setChannelNameColor(ext->displaySettings()->callColor());
+  setChannelNameColor(ext->displaySettings()->channelNameColor());
   enableShowCurrentContact(ext->displaySettings()->showContact());
   setTXBacklightDuration(ext->displaySettings()->backlightDurationTX());
 


### PR DESCRIPTION
I was seeing issues with `callDisplayColor` and `channelNameColor` on my 578.
I found one specific bug for `channelNameColor` which was probably copy/paste, so I fixed that.
Then I noticed when comparing to the 878 code that this code wasn't using `NameColor::decode`, `NameColor::encode`, `TextColor::decode`, and `TextColor::encode` in similar places, so I changed those also.
After this, a read from the 578 showed the correct colors in the app and changing a couple colors looked like it was working correctly now.
(I still some strange issue around `rxGroupList` where it is empty after a read, but I'll look into that at a later time.)