### PR TITLE
Fix misleading error message in AnytoneInterface::ReadResponse

### DIFF
--- a/lib/anytone_interface.cc
+++ b/lib/anytone_interface.cc
@@ -31,7 +31,7 @@ AnytoneInterface::ReadResponse::check(uint32_t addr, QString &msg) const {
     return false;
   }
   if (16 != size) {
-    msg = QObject::tr("Invalid read response: Expected size 64 got %1").arg((int)size);
+    msg = QObject::tr("Invalid read response: Expected size 16 got %1").arg((int)size);
     return false;
   }
   // Compute checksum


### PR DESCRIPTION
The error message reported 'Expected size 64' but the code actually checks for size 16. This makes debugging harder when the error occurs.

Changed line 34 to correctly report 'Expected size 16'.