### PR TITLE
Update the Flatpak

### DIFF
--- a/de.darc.dm3mat.qdmr.yaml
+++ b/de.darc.dm3mat.qdmr.yaml
@@ -1,6 +1,6 @@
 app-id: de.darc.dm3mat.qdmr
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 command: qdmr
 rename-desktop-file: qdmr.desktop
@@ -39,8 +39,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/libusb/libusb.git
-        tag: v1.0.28
-        commit: a61afe5f75d969c4561a1d0ad753aa23cee6329a
+        tag: v1.0.29
+        commit: 15a7ebb4d426c5ce196684347d2b7cafad862626
 
   - name: qdmr
     buildsystem: cmake-ninja


### PR DESCRIPTION
The 6.8 runtime is no longer supported (and 6.10 brings unnecessary yaml-cpp/libusb compatibility issues).

Tested and seems to work fine, except for three small issues that are **not caused by this update** and also happen with the 6.8 runtime and older libusb:

1. When QDMR is started for the first time, a help window also appears, but in the background. This makes the main window unclickable.
2. The satellites update does not seem to work. This is printed on stdout:
```
$ flatpak run de.darc.dm3mat.qdmr
Debug in src/application.cc@915: Set icon theme to 'light'.
Debug in src/application.cc@77: Search for translation in ':/i18n/cs_CZ.qm'.
Debug in src/application.cc@77: Search for translation in ':/i18n/cs.qm'.
ERROR in src/repeaterdatabase.cc@351: Cannot open cache '/home/asciiwolf/.var/app/de.darc.dm3mat.qdmr/data/DM3MAT/qdmr/repeaterbook.cache.json': No such file or directory.
ERROR in src/repeaterdatabase.cc@351: Cannot open cache '/home/asciiwolf/.var/app/de.darc.dm3mat.qdmr/data/DM3MAT/qdmr/repeaterbook.cache.json': No such file or directory.
Debug in src/repeaterdatabase.cc@489: Query https://repeatermap.de/apinew.php'.
ebug in src/repeaterdatabase.cc@489: Query https://radioid.net/static/map.json'.
ERROR in src/repeaterdatabase.cc@351: Cannot open cache '/home/asciiwolf/.var/app/de.darc.dm3mat.qdmr/data/DM3MAT/qdmr/radioidrepeater.cache.json': No such file or directory.
QString::arg: Argument missing: Cannot open talk group list '/home/asciiwolf/.var/app/de.darc.dm3mat.qdmr/data/DM3MAT/qdmr/talkgroups.json': , No such file or directory
ERROR in lib/talkgroupdatabase.cc@112: Cannot open talk group list '/home/asciiwolf/.var/app/de.darc.dm3mat.qdmr/data/DM3MAT/qdmr/talkgroups.json': 
ERROR in lib/orbitalelementsdatabase.cc@278: Cannot open orbital elements '/home/asciiwolf/.var/app/de.darc.dm3mat.qdmr/data/DM3MAT/qdmr/elements.json': No such file or directory
ERROR in lib/transponderdatabase.cc@206: Cannot open transponders '/home/asciiwolf/.var/app/de.darc.dm3mat.qdmr/data/DM3MAT/qdmr/transponders.json': No such file or directory
Debug in src/application.cc@143: Last known position: 
Debug in src/mainwindow.cc@35: Create main window using icon theme 'light'.
Debug in lib/talkgroupdatabase.cc@140: Loaded talk group database with 1735 entries from /home/asciiwolf/.var/app/de.darc.dm3mat.qdmr/data/DM3MAT/qdmr/talkgroups.json.
Debug in src/repeatermapsource.cc@51: Loaded 3387 elements from https://repeatermap.de/apinew.php.
Debug in lib/orbitalelementsdatabase.cc@323: Loaded orbital elements with 99 entries from /home/asciiwolf/.var/app/de.darc.dm3mat.qdmr/data/DM3MAT/qdmr/elements.json.
ERROR in lib/satellitedatabase.cc@435: Cannot open satellites '/home/asciiwolf/.var/app/de.darc.dm3mat.qdmr/data/DM3MAT/qdmr/satellites.json': No such file or directory
Debug in src/radioidrepeatersource.cc@55: Loaded 10551 elements from https://radioid.net/static/map.json.
Debug in lib/transponderdatabase.cc@247: Loaded transponder with 1659 entries from /home/asciiwolf/.var/app/de.darc.dm3mat.qdmr/data/DM3MAT/qdmr/transponders.json.
```
3. Some of the elements are too narrow. For example:
<img width="785" height="114" alt="screenshot" src="https://github.com/user-attachments/assets/db00750f-7012-4314-9608-87b82738b114" />