### PR TITLE
Hide elements that are already in lists. 

### DIFF
--- a/src/channelselectiondialog.cc
+++ b/src/channelselectiondialog.cc
@@ -1,6 +1,7 @@
 #include "channelselectiondialog.hh"
 #include "channel.hh"
 #include "channelcombobox.hh"
+#include "configreference.hh"
 
 #include <QDialogButtonBox>
 #include <QLabel>
@@ -35,7 +36,9 @@ ChannelSelectionDialog::channel() const {
 /* ********************************************************************************************* *
  * Implementation of MultiChannelSelectionDialog
  * ********************************************************************************************* */
-MultiChannelSelectionDialog::MultiChannelSelectionDialog(ChannelList *lst, bool includeSelectedChannel, bool digitalOnly, QWidget *parent)
+MultiChannelSelectionDialog::MultiChannelSelectionDialog(
+  ChannelList *lst, bool includeSelectedChannel, bool digitalOnly, ChannelRefList *exclude,
+  QWidget *parent)
   : QDialog(parent)
 {
   _channel = new QListWidget();
@@ -48,7 +51,9 @@ MultiChannelSelectionDialog::MultiChannelSelectionDialog(ChannelList *lst, bool 
   }
   for (int i=0; i<lst->count(); i++) {
     Channel *channel = lst->channel(i);
-    if (digitalOnly && channel->is<FMChannel>())
+    if (digitalOnly && channel->is<AnalogChannel>())
+      continue;
+    if (exclude && exclude->has(channel))
       continue;
     QListWidgetItem *item = new QListWidgetItem(channel->name());
     item->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsEnabled);

--- a/src/channelselectiondialog.hh
+++ b/src/channelselectiondialog.hh
@@ -7,6 +7,7 @@ class Channel;
 class ChannelList;
 class ChannelComboBox;
 class QListWidget;
+class ChannelRefList;
 
 class ChannelSelectionDialog: public QDialog
 {
@@ -28,7 +29,8 @@ class MultiChannelSelectionDialog: public QDialog
 
 public:
   MultiChannelSelectionDialog(ChannelList *lst, bool includeSelectedChannel=false,
-                              bool digitalOnly=false, QWidget *parent=nullptr);
+                              bool digitalOnly=false, ChannelRefList *exclude=nullptr,
+                              QWidget *parent=nullptr);
 
   QList<Channel *> channel() const;
 

--- a/src/contactselectiondialog.cc
+++ b/src/contactselectiondialog.cc
@@ -10,7 +10,8 @@
 /* ********************************************************************************************* *
  * Implementation of MultiGroupCallSelectionDialog
  * ********************************************************************************************* */
-MultiGroupCallSelectionDialog::MultiGroupCallSelectionDialog(ContactList *contacts, bool showPrivateCalls, QWidget *parent)
+MultiGroupCallSelectionDialog::MultiGroupCallSelectionDialog(
+  ContactList *contacts, bool showPrivateCalls, DMRContactRefList *exclude, QWidget *parent)
   : QDialog(parent)
 {
   _contacts = new QListWidget();
@@ -21,8 +22,10 @@ MultiGroupCallSelectionDialog::MultiGroupCallSelectionDialog(ContactList *contac
     Contact *contact = contacts->contact(i);
     if (! contact->is<DMRContact>())
       continue;
-    DMRContact *digi = contact->as<DMRContact>();
-    QListWidgetItem *item = new QListWidgetItem(digi->name());
+    if (exclude && exclude->has(contact))
+      continue;
+    auto digi = contact->as<DMRContact>();
+    auto item = new QListWidgetItem(digi->name());
     item->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsEnabled);
     item->setData(Qt::UserRole, QVariant::fromValue(digi));
     item->setCheckState(Qt::Unchecked);

--- a/src/contactselectiondialog.hh
+++ b/src/contactselectiondialog.hh
@@ -8,6 +8,7 @@ class DMRContact;
 class ContactList;
 class QListWidget;
 class QLabel;
+class DMRContactRefList;
 
 
 class MultiGroupCallSelectionDialog: public QDialog
@@ -15,7 +16,8 @@ class MultiGroupCallSelectionDialog: public QDialog
   Q_OBJECT
 
 public:
-  explicit MultiGroupCallSelectionDialog(ContactList *contacts, bool showPrivateCalls=false, QWidget *parent=nullptr);
+  explicit MultiGroupCallSelectionDialog(ContactList *contacts, bool showPrivateCalls=false,
+    DMRContactRefList *exclude=nullptr, QWidget *parent=nullptr);
 
   QList<DMRContact *> contacts();
 

--- a/src/roamingchannelselectiondialog.cc
+++ b/src/roamingchannelselectiondialog.cc
@@ -6,22 +6,25 @@
 #include <QVBoxLayout>
 
 MultiRoamingChannelSelectionDialog::MultiRoamingChannelSelectionDialog(
-    Config *config, QWidget *parent)
+    Config *config, RoamingChannelRefList *exclude, QWidget *parent)
   : QDialog(parent), _channels(nullptr)
 {
   setWindowTitle(tr("Select roaming channels"));
   _channels = new QListWidget();
   for (int i=0; i<config->roamingChannels()->count(); i++) {
-    QListWidgetItem *item = new QListWidgetItem(config->roamingChannels()->channel(i)->name());
+    auto channel = config->roamingChannels()->channel(i);
+    if (exclude && exclude->has(channel))
+      continue;
+    auto item = new QListWidgetItem(channel->name());
     item->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsEnabled);
-    item->setData(Qt::UserRole, QVariant::fromValue(config->roamingChannels()->channel(i)));
+    item->setData(Qt::UserRole, QVariant::fromValue(channel));
     item->setCheckState(Qt::Unchecked);
     _channels->addItem(item);
   }
 
-  QDialogButtonBox *box = new QDialogButtonBox(QDialogButtonBox::Ok|QDialogButtonBox::Cancel);
+  auto box = new QDialogButtonBox(QDialogButtonBox::Ok|QDialogButtonBox::Cancel);
 
-  QVBoxLayout *layout = new QVBoxLayout();
+  auto layout = new QVBoxLayout();
   layout->addWidget(_channels);
   layout->addWidget(box);
   setLayout(layout);

--- a/src/roamingchannelselectiondialog.hh
+++ b/src/roamingchannelselectiondialog.hh
@@ -8,13 +8,15 @@
 class Config;
 class RoamingChannel;
 class QListWidget;
+class RoamingChannelRefList;
+
 
 class MultiRoamingChannelSelectionDialog : public QDialog
 {
   Q_OBJECT
 
 public:
-  MultiRoamingChannelSelectionDialog(Config *config, QWidget *parent=nullptr);
+  MultiRoamingChannelSelectionDialog(Config *config, RoamingChannelRefList *exclude=nullptr, QWidget *parent=nullptr);
 
   QList<RoamingChannel *> channels() const;
 

--- a/src/roamingzonedialog.cc
+++ b/src/roamingzonedialog.cc
@@ -64,7 +64,7 @@ RoamingZoneDialog::onAddDMRChannel() {
 
 void
 RoamingZoneDialog::onAddRoamingChannel() {
-  MultiRoamingChannelSelectionDialog dia(_config);
+  MultiRoamingChannelSelectionDialog dia(_config, _myZone->channels());
   if (QDialog::Accepted != dia.exec())
     return;
 

--- a/src/rxgrouplistdialog.cc
+++ b/src/rxgrouplistdialog.cc
@@ -66,13 +66,13 @@ RXGroupListDialog::construct() {
 
 void
 RXGroupListDialog::onAddGroup() {
-  MultiGroupCallSelectionDialog dialog(_config->contacts(), false);
+  MultiGroupCallSelectionDialog dialog(_config->contacts(), false, _myGroupList->contacts());
   if (QDialog::Accepted != dialog.exec())
     return;
 
   QList<DMRContact *> contacts = dialog.contacts();
   foreach (DMRContact *contact, contacts) {
-    if (0 <= _myGroupList->contacts()->indexOf(contact))
+    if (_myGroupList->contacts()->has(contact))
       continue;
     _myGroupList->addContact(contact);
   }

--- a/src/zonedialog.cc
+++ b/src/zonedialog.cc
@@ -58,7 +58,7 @@ ZoneDialog::construct() {
 
 void
 ZoneDialog::onAddChannelA() {
-  MultiChannelSelectionDialog dia(_config->channelList());
+  MultiChannelSelectionDialog dia(_config->channelList(), false, false, _myZone->A());
   if (QDialog::Accepted != dia.exec())
     return;
 
@@ -89,7 +89,7 @@ ZoneDialog::onRemChannelA() {
 
 void
 ZoneDialog::onAddChannelB() {
-  MultiChannelSelectionDialog dia(_config->channelList());
+  MultiChannelSelectionDialog dia(_config->channelList(), false, false, _myZone->B());
   if (QDialog::Accepted != dia.exec())
     return;
 


### PR DESCRIPTION
This includes channels in zones, contacts in group lists and channels in roaming zones.