### PR TITLE
DM-32UV: set boot display mode when encoding intro lines

### DIFF
--- a/lib/dm32uv_codeplug.cc
+++ b/lib/dm32uv_codeplug.cc
@@ -3294,6 +3294,11 @@ DM32UVCodeplug::GeneralSettingsElement::encode(Context &ctx, const ErrorStack &e
   Q_UNUSED(err);
   setBootMessage1(ctx.config()->settings()->introLine1());
   setBootMessage2(ctx.config()->settings()->introLine2());
+  if (ctx.config()->settings()->introLine1().isEmpty() &&
+      ctx.config()->settings()->introLine2().isEmpty())
+    setBootDisplay(BootDisplay::Image);
+  else
+    setBootDisplay(BootDisplay::Message);
   enableVoicePrompt(ctx.config()->settings()->speech());
   if (ctx.config()->settings()->voxDisabled())
     setVOXLevel(Level::null());


### PR DESCRIPTION
Fixes #858.

`GeneralSettingsElement::encode()` writes `bootMessage1`/`bootMessage2` from the config's intro lines but never calls `setBootDisplay()`. The getter, setter, and `BootDisplay` enum all exist and work, they're just not called during encoding.

With `--init-codeplug` or zeroed memory, `bootDisplay` defaults to 0 (`Image`), so the radio shows the Baofeng splash and skips the intro text.

The fix sets `BootDisplay::Message` when either intro line is non-empty, and `BootDisplay::Image` when both are empty.

Builds and passes DM-32UV test on aarch64 (Raspberry Pi 4B, Debian Trixie). The one pre-existing test failure (Config/testGNSSSettings) is unrelated.