### PR TITLE
DM-32UV: fix mic level range and FM decode asymmetry

### DIFF
--- a/lib/dm32uv_codeplug.cc
+++ b/lib/dm32uv_codeplug.cc
@@ -3242,7 +3242,7 @@ DM32UVCodeplug::GeneralSettingsElement::setSTEMode(STEMode mode) {
 
 Level
 DM32UVCodeplug::GeneralSettingsElement::fmMicLevel() const {
-  return Level::fromValue(getUInt8(Offset::fmMicLevel())+ 1, Limit::micGain());
+  return Level::fromValue(getUInt8(Offset::fmMicLevel()), Limit::micGain());
 }
 
 void

--- a/lib/dm32uv_limits.cc
+++ b/lib/dm32uv_limits.cc
@@ -27,7 +27,7 @@ DM32UVLimits::DM32UVLimits(QObject *parent)
           -1, DM32UVCodeplug::GeneralSettingsElement::Limit::bootMessageLength(), RadioLimitString::ASCII) },
         { "introLine2", new RadioLimitString(
           -1, DM32UVCodeplug::GeneralSettingsElement::Limit::bootMessageLength(), RadioLimitString::ASCII) },
-        { "micLevel", new RadioLimitLevel({1, 10}, false) },
+        { "micLevel", new RadioLimitLevel({1, 5}, false) },
         { "speech", new RadioLimitIgnoredBool() },
         { "power", new RadioLimitEnum {
             unsigned(Channel::Power::Low),


### PR DESCRIPTION
Fixes #860.

Two issues with mic level encoding:

1. `dm32uv_limits.cc` defined the micLevel range as {1, 10} but the hardware stores values 0-4 at offsets 0x00a6 (FM) and 0x00a7 (DMR). `Level::mapTo()` integer division caused most UI values to map to the same raw byte, making changes inaudible. Changed to {1, 5} to match the hardware.

2. The FM mic level decode path added `+1` to the raw byte before `Level::fromValue()`, but the DMR decode path did not, and neither write path subtracted it. This broke read-write round-trip consistency. Removed the `+1`.

The radio also has a "digital mic enhance" (1-3) field that isn't implemented yet. Left as future work since it needs new offsets and properties.

Builds and passes DM-32UV test in isolation on aarch64 (Raspberry Pi 4B, Debian Trixie).