### PR TITLE
DM-32UV: fix four codeplug encoding bugs

### DIFF
--- a/lib/dm32uv_codeplug.cc
+++ b/lib/dm32uv_codeplug.cc
@@ -590,7 +590,7 @@ DM32UVCodeplug::ChannelElement::decodeSelectiveCall(uint16_t code) {
   code &= 0x3fff;
 
   if (0 == type) {
-    return SelectiveCall(double((code>>4)&0xf)*10 + double((code>>4)&0xf)*1 + double(code & 0xf)/10);
+    return SelectiveCall(double((code>>8)&0xf)*10 + double((code>>4)&0xf)*1 + double(code & 0xf)/10);
   } else if ((1 == type) || (2 == type)) {
     return SelectiveCall(code, 2 == type);
   }
@@ -2512,8 +2512,9 @@ DM32UVCodeplug::GeneralSettingsElement::setBacklightDuration(Interval duration) 
     setUInt8(Offset::backlightDuration(), (unsigned int)BacklightDuration::T4min);
   } else if (duration.minutes() <= 5) {
     setUInt8(Offset::backlightDuration(), (unsigned int)BacklightDuration::T5min);
+  } else {
+    setUInt8(Offset::backlightDuration(), (unsigned int)BacklightDuration::Infinity);
   }
-  setUInt8(Offset::backlightDuration(), (unsigned int)BacklightDuration::Infinity);
 }
 
 
@@ -3417,7 +3418,7 @@ DM32UVCodeplug::APRSSettingsElement::setFixedLocation(const QGeoCoordinate &coor
 
 void
 DM32UVCodeplug::APRSSettingsElement::enableFixedLocation(bool enable) {
-  setUInt8(Offset::enableFixedLocation(), enable ? 0x01 : 0x02);
+  setUInt8(Offset::enableFixedLocation(), enable ? 0x01 : 0x00);
 }
 
 
@@ -3565,9 +3566,6 @@ DM32UVCodeplug::APRSSettingsElement::encode(Context &ctx, const ErrorStack &err)
     setFixedLocation(ctx.config()->settings()->gnss()->fixedPosition());
     enableFixedLocation(ctx.config()->settings()->gnss()->fixedPositionEnabled());
   }
-
-  ctx.config()->settings()->gnss()->setFixedPosition(fixedLocation());
-  ctx.config()->settings()->gnss()->enableFixedPosition(fixedLocationEnabled());
 
   if (0 == ctx.count<DMRAPRSSystem>()) {
     setDestinationId(0);


### PR DESCRIPTION
Four bugs in dm32uv_codeplug.cc:

1. **setBacklightDuration() always sets Infinity** -- the final setUInt8 call at line 2516 was outside the if/else chain, unconditionally overwriting whatever was just set. Added the missing `else`.

2. **decodeSelectiveCall() CTCSS tens digit reads wrong nibble** -- `(code>>4)&0xf` was used for both tens and units. The tens digit should be `(code>>8)&0xf`. Compare with encodeSelectiveCall() which correctly uses bit positions 8, 4, and 0.

3. **enableFixedLocation(false) writes 0x02** -- fixedLocationEnabled() checks `!= 0`, so both true (0x01) and false (0x02) read back as enabled. Changed false to write 0x00.

4. **APRSSettingsElement::encode() had decode lines** -- two lines at 3570-3571 read from the codeplug back into the config (setFixedPosition/enableFixedPosition), clearly copy-pasted from decode(). Removed them.

All 27 tests pass on aarch64 (Raspberry Pi 4B, Debian Trixie).