### PR TITLE
DR-1801UV: fix four codeplug encoding bugs

### DIFF
--- a/lib/dr1801uv_codeplug.cc
+++ b/lib/dr1801uv_codeplug.cc
@@ -1953,6 +1953,7 @@ DR1801UVCodeplug::ScanListElement::encode(ScanList *obj, Context &ctx, const Err
   }
 
   unsigned int n = std::min(Limit::memberCount(), (unsigned int)obj->count());
+  setEntryCount(n);
   for (unsigned int i=0; i<n; i++) {
     setEntryIndex(i, ctx.index(obj->channel(i)));
   }
@@ -2191,7 +2192,7 @@ DR1801UVCodeplug::VFOBankElement::nameA() const {
 }
 void
 DR1801UVCodeplug::VFOBankElement::setNameA(const QString &name) {
-  writeASCII(Offset::nameB(), name, Limit::nameLength(), 0x00);
+  writeASCII(Offset::nameA(), name, Limit::nameLength(), 0x00);
 }
 
 QString
@@ -2390,7 +2391,7 @@ void
 DR1801UVCodeplug::DTMFSettingsElement::setRadioID(const QString &id) {
   setUInt8(Offset::radioIDLength(),
            std::min(Limit::radioIDLength(), (unsigned int)id.length()));
-  writeASCII(Offset::radioIDLength(), id, Limit::radioIDLength(), 0x00);
+  writeASCII(Offset::radioID(), id, Limit::radioIDLength(), 0x00);
 }
 
 QString
@@ -2665,8 +2666,8 @@ DR1801UVCodeplug::DTMFIDElement::number() const {
 
 void
 DR1801UVCodeplug::DTMFIDElement::setNumber(const QString &number) {
-  QString lnumber = number.toLower();
-  QRegularExpression re("[0-9a-d*#]+");
+  QString lnumber = number.toUpper();
+  QRegularExpression re("[0-9A-D*#]+");
   if (! re.match(lnumber).isValid())
     return;
   setNumberLength(std::min(Limit::numberLength(), (unsigned int)lnumber.length()));


### PR DESCRIPTION
Four bugs in dr1801uv_codeplug.cc:

1. **setNameA() writes to wrong offset** -- used `Offset::nameB()` instead of `Offset::nameA()`. VFO A name was never written; VFO B name was overwritten with A's value.

2. **setRadioID() writes string to length offset** -- `writeASCII()` used `Offset::radioIDLength()` instead of `Offset::radioID()`. The string overwrote the just-written length byte at 0x0005 and the actual ID field at 0x0000 was never touched. The getter correctly reads from `Offset::radioID()`.

3. **setNumber() case mismatch** -- input was lowercased (`toLower()`) but `_bin_dtmf_tab` has uppercase A-D. `indexOf()` returned -1 for letters a-d, writing 0xFF to the codeplug. Changed to `toUpper()` to match the table.

4. **ScanListElement::encode() missing entry count** -- never called `setEntryCount()`. The link path in `linkScanListObj()` iterates `entryCount()` times, so without it the radio sees zero entries. Compare with `ZoneElement::encode()` and `GroupListElement::encode()` which both set the count.

All 27 tests pass on aarch64 (Raspberry Pi 4B, Debian Trixie).