### PR TITLE
Fix fromGHz() multiplier and KHzString typo

### DIFF
--- a/lib/frequency.cc
+++ b/lib/frequency.cc
@@ -4,7 +4,7 @@
 
 
 inline const QString HzString = QStringLiteral("Hz");
-inline const QString KHzString = QStringLiteral("MHz");
+inline const QString KHzString = QStringLiteral("kHz");
 inline const QString MHzString = QStringLiteral("MHz");
 inline const QString GHzString = QStringLiteral("GHz");
 

--- a/lib/frequency.hh
+++ b/lib/frequency.hh
@@ -95,7 +95,7 @@ public:
   static inline FrequencyOffset fromHz(qint64 Hz)   { return FrequencyOffset(Hz); }             ///< Unit conversion.
   static inline FrequencyOffset fromkHz(double kHz) { return FrequencyOffset(kHz*1e3); }      ///< Unit conversion.
   static inline FrequencyOffset fromMHz(double MHz) { return FrequencyOffset(MHz*1e6); }      ///< Unit conversion.
-  static inline FrequencyOffset fromGHz(double GHz) { return FrequencyOffset(GHz*1e6); }      ///< Unit conversion.
+  static inline FrequencyOffset fromGHz(double GHz) { return FrequencyOffset(GHz*1e9); }      ///< Unit conversion.
 };
 
 
@@ -153,7 +153,7 @@ public:
   static inline Frequency fromHz(quint64 Hz)  { return Frequency(Hz); }      ///< Unit conversion.
   static inline Frequency fromkHz(double kHz) { return Frequency(kHz*1e3); } ///< Unit conversion.
   static inline Frequency fromMHz(double MHz) { return Frequency(MHz*1e6); } ///< Unit conversion.
-  static inline Frequency fromGHz(double GHz) { return Frequency(GHz*1e6); } ///< Unit conversion.
+  static inline Frequency fromGHz(double GHz) { return Frequency(GHz*1e9); } ///< Unit conversion.
 
 public:
   /** Searches for the nearest frequency and returns an associated value. */


### PR DESCRIPTION
Two bugs in the frequency handling code:

1. **fromGHz() uses 1e6 instead of 1e9** (frequency.hh lines 98, 156) -- both `Frequency::fromGHz()` and `FrequencyOffset::fromGHz()` multiply by 1e6 (the MHz multiplier) instead of 1e9. All GHz values are 1000x too small. The correct multipliers for fromkHz (*1e3) and fromMHz (*1e6) are right above these lines.

2. **KHzString = "MHz"** (frequency.cc line 7) -- `KHzString` is defined as `QStringLiteral("MHz")` instead of `"kHz"`. This means `unitName(Unit::kHz)` returns "MHz". `MHzString` on the next line is also "MHz" so these were likely duplicated by mistake.

All 27 tests pass on aarch64.