### PR TITLE
Fix qstring_is_ascii(), uninitialized _betaWarning, and static regex

### DIFF
--- a/lib/frequency.cc
+++ b/lib/frequency.cc
@@ -58,7 +58,7 @@ FrequencyBase::parse(const QString &value, Qt::CaseSensitivity caseSensitivity) 
   QRegularExpression::PatternOption patternOption = caseSensitivity == Qt::CaseInsensitive
     ? QRegularExpression::PatternOption::CaseInsensitiveOption : QRegularExpression::PatternOption::NoPatternOption;
 
-  static QRegularExpression re(R"(\s*(\+|-)?\s*([0-9]+)(?:\.([0-9]*)|)\s*([kMG]|[kMG]?Hz|)\s*)", patternOption);
+  QRegularExpression re(R"(\s*(\+|-)?\s*([0-9]+)(?:\.([0-9]*)|)\s*([kMG]|[kMG]?Hz|)\s*)", patternOption);
   QRegularExpressionMatch match = re.match(value);
 
   if (!match.hasMatch())

--- a/lib/radiolimits.cc
+++ b/lib/radiolimits.cc
@@ -7,7 +7,7 @@
 // Utility function to check string content for ASCII encoding
 inline bool qstring_is_ascii(const QString &text) {
   foreach (QChar c, text) {
-    if ((c.unicode() < 0x1f) && (0x7f != c.unicode()))
+    if ((c.unicode() < 0x20) || (c.unicode() > 0x7e))
       return false;
   }
   return true;
@@ -1043,7 +1043,7 @@ RadioLimits::RadioLimits(bool betaWarning, QObject *parent)
 }
 
 RadioLimits::RadioLimits(const std::initializer_list<std::pair<QString, RadioLimitElement *> > &list, QObject *parent)
-  : RadioLimitItem(list, parent),
+  : RadioLimitItem(list, parent), _betaWarning(false),
     _hasCallSignDB(false), _callSignDBImplemented(false), _numCallSignDBEntries(0),
     _hasSatelliteConfig(false), _satelliteConfigImplemented(false), _numSatellites(0)
 {


### PR DESCRIPTION
Three bugs in the shared library:

1. **qstring_is_ascii() accepts non-ASCII** (radiolimits.cc line 10) -- the condition used `&&` instead of `||`. It only rejected control chars below 0x1F, never characters above 0x7E. Unicode characters, accented letters, etc. all passed as "ASCII". Changed to `(c < 0x20) || (c > 0x7e)`.

2. **_betaWarning uninitialized** (radiolimits.cc line 1046) -- the second `RadioLimits` constructor (taking an initializer_list) initializes all members except `_betaWarning`. The first constructor initializes it from a parameter. Reading it in `verifyConfig()` is undefined behavior. Added `_betaWarning(false)` to the initializer list.

3. **Static regex with varying options** (frequency.cc line 61) -- `FrequencyBase::parse()` created a `static QRegularExpression` with a `patternOption` computed from the `caseSensitivity` parameter. After the first call, the regex was never reconstructed, so subsequent calls with different case sensitivity were silently ignored. Removed `static`.

All 27 tests pass on aarch64.