### PR TITLE
AnyTone: fix seven codeplug bugs across D868UV/D878UV/D578UV

### DIFF
--- a/lib/anytone_codeplug.cc
+++ b/lib/anytone_codeplug.cc
@@ -499,7 +499,7 @@ AnytoneCodeplug::ChannelElement::dtmfIDIndex() const {
 }
 void
 AnytoneCodeplug::ChannelElement::setDTMFIDIndex(unsigned idx) {
-  setUInt8(Offset::fiveToneIDIndex(), idx);
+  setUInt8(Offset::dtmfIDIndex(), idx);
 }
 
 unsigned
@@ -1142,7 +1142,7 @@ AnytoneCodeplug::GroupListElement::fromGroupListObj(const RXGroupList *lst, Cont
   for (uint8_t i=0; i<Limit::members(); i++) {
     // Skip non-private-call entries
     while((lst->count() > j) && (DMRContact::GroupCall != lst->contact(j)->type())) {
-      logWarn() << "Contact '" << lst->contact(i)->name() << "' in group list '" << lst->name()
+      logWarn() << "Contact '" << lst->contact(j)->name() << "' in group list '" << lst->name()
                 << "' is not a group call. Skip entry.";
       j++;
     }
@@ -1402,7 +1402,7 @@ AnytoneCodeplug::ScanListElement::fromScanListObj(ScanList *lst, Context &ctx) {
     setMemberIndex(i, ctx.index(lst->channel(i)));
   }
 
-  return false;
+  return true;
 }
 
 
@@ -2026,7 +2026,7 @@ AnytoneCodeplug::ZoneChannelListElement::clear() {
 
 bool
 AnytoneCodeplug::ZoneChannelListElement::hasChannelA(unsigned n) const {
-  return 0xffff == channelIndexA(n);
+  return 0xffff != channelIndexA(n);
 }
 unsigned
 AnytoneCodeplug::ZoneChannelListElement::channelIndexA(unsigned n) const {
@@ -2043,7 +2043,7 @@ AnytoneCodeplug::ZoneChannelListElement::clearChannelIndexA(unsigned n) {
 
 bool
 AnytoneCodeplug::ZoneChannelListElement::hasChannelB(unsigned n) const {
-  return 0xffff == channelIndexB(n);
+  return 0xffff != channelIndexB(n);
 }
 unsigned
 AnytoneCodeplug::ZoneChannelListElement::channelIndexB(unsigned n) const {

--- a/lib/d578uv_codeplug.cc
+++ b/lib/d578uv_codeplug.cc
@@ -501,7 +501,7 @@ D578UVCodeplug::GeneralSettingsElement::TimeZone::_timeZones = {
   QTimeZone(-10800), QTimeZone(- 7200), QTimeZone(- 3600), QTimeZone(     0), QTimeZone(  3600),
   QTimeZone(  7200), QTimeZone( 10800), QTimeZone( 12600), QTimeZone( 14400), QTimeZone( 16200),
   QTimeZone( 18000), QTimeZone( 19800), QTimeZone( 20700), QTimeZone( 21600), QTimeZone( 25200),
-  QTimeZone( 28600), QTimeZone( 30600), QTimeZone( 32400), QTimeZone( 36000), QTimeZone( 39600),
+  QTimeZone( 28800), QTimeZone( 30600), QTimeZone( 32400), QTimeZone( 36000), QTimeZone( 39600),
   QTimeZone( 43200), QTimeZone( 46800) };
 
 QTimeZone

--- a/lib/d878uv_codeplug.cc
+++ b/lib/d878uv_codeplug.cc
@@ -682,7 +682,7 @@ D878UVCodeplug::RoamingChannelElement::setTXFrequency(unsigned hz) {
 
 bool
 D878UVCodeplug::RoamingChannelElement::hasColorCode() const {
-  return ColorCodeValue::Disabled == getUInt8(Offset::colorCode());
+  return ColorCodeValue::Disabled != getUInt8(Offset::colorCode());
 }
 unsigned
 D878UVCodeplug::RoamingChannelElement::colorCode() const {
@@ -809,7 +809,7 @@ void
 D878UVCodeplug::RoamingZoneElement::clearMember(unsigned n) {
   if (n >= Limit::numMembers())
     return;
-  setMember(Offset::members() + n*Offset::betweenMembers(), 0xff);
+  setMember(n, 0xff);
 }
 
 QString


### PR DESCRIPTION
Seven bugs across the AnyTone radio implementations:

**anytone_codeplug.cc:**

1. **setDTMFIDIndex() writes to wrong offset** (line 502) -- used `Offset::fiveToneIDIndex()` instead of `Offset::dtmfIDIndex()`. The getter reads from the correct offset. Copy-paste error from setFiveToneIDIndex() above it.

2. **fromScanListObj() returns false on success** (line 1405) -- every other `from*Obj` method returns true on success. This signals failure to callers during scan list encoding.

3. **fromGroupListObj() warning uses wrong index** (line 1145) -- accesses `lst->contact(i)` (codeplug slot index) instead of `lst->contact(j)` (list entry index). Out-of-bounds when `i >= lst->count()`.

4. **hasChannelA/B() inverted** (lines 2029, 2046) -- returns true when index equals the 0xffff sentinel (no channel). Changed `==` to `!=`.

**d878uv_codeplug.cc:**

5. **hasColorCode() inverted** (line 685) -- returns true when color code is Disabled. Changed `==` to `!=`.

6. **clearMember() double-applies offset** (line 812) -- passes pre-computed `Offset::members() + n*betweenMembers()` to `setMember()` which adds the offset again internally. Writes to wrong memory. Changed to `setMember(n, 0xff)`.

**d578uv_codeplug.cc:**

7. **UTC+8 timezone typo** (line 504) -- value 28600 (UTC+7:56:40) should be 28800 (8*3600). The D878UV file has the correct value. Affects D578UV users in China, Singapore, Philippines, Western Australia, etc.

All 27 tests pass on aarch64.