### PR TITLE
Add UI language selection menu

### DIFF
--- a/i18n/ru_RU.ts
+++ b/i18n/ru_RU.ts
@@ -1,0 +1,4095 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
+<context>
+    <name>AMChannelDialog</name>
+    <message>
+        <location filename="../src/amchanneldialog.cc" line="11"/>
+        <source>Squelch</source>
+        <translation>Шумоподавитель</translation>
+    </message>
+</context>
+<context>
+    <name>APRSSelect</name>
+    <message>
+        <location filename="../src/aprsselect.cc" line="44"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+</context>
+<context>
+    <name>APRSSystemDialog</name>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="102"/>
+        <source>Create APRS system</source>
+        <translation>Создать систему APRS</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="110"/>
+        <source>Edit APRS system</source>
+        <translation>Изменить систему APRS</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="133"/>
+        <source>[Selected]</source>
+        <translation type="unfinished">[Selected]</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../src/aboutdialog.ui" line="14"/>
+        <location filename="../shared/ui/aboutdialog.ui" line="20"/>
+        <location filename="../shared/ui/aboutdialog.ui" line="37"/>
+        <location filename="../shared/ui/aboutdialog.ui" line="55"/>
+        <source>About qdmr</source>
+        <translation>О программе qdmr</translation>
+    </message>
+    <message>
+        <location filename="../shared/ui/aboutdialog.ui" line="88"/>
+        <source>Supported Radios</source>
+        <translation>Поддерживаемые радиостанции</translation>
+    </message>
+</context>
+<context>
+    <name>Application</name>
+    <message>
+        <location filename="../src/application.cc" line="180"/>
+        <location filename="../src/application.cc" line="198"/>
+        <location filename="../src/application.cc" line="520"/>
+        <source>Unsaved changes to codeplug.</source>
+        <translation>Несохранённые изменения кодплага.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="181"/>
+        <location filename="../src/application.cc" line="199"/>
+        <location filename="../src/application.cc" line="521"/>
+        <source>There are unsaved changes to the current codeplug. These changes are lost if you proceed.</source>
+        <translation>В текущем кодплаге есть несохранённые изменения. Они будут потеряны, если продолжить.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="207"/>
+        <source>Open codeplug</source>
+        <translation>Открыть кодплаг</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="209"/>
+        <source>Codeplug Files (*.yaml);;Codeplug Files, old format (*.conf *.csv *.txt);;All Files (*)</source>
+        <translation>Файлы кодплага (*.yaml);;Файлы кодплага, старый формат (*.conf *.csv *.txt);;Все файлы (*)</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="286"/>
+        <location filename="../src/application.cc" line="323"/>
+        <location filename="../src/application.cc" line="362"/>
+        <source>Cannot open file</source>
+        <translation>Не удалось открыть файл</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="217"/>
+        <location filename="../src/application.cc" line="231"/>
+        <location filename="../src/application.cc" line="250"/>
+        <location filename="../src/application.cc" line="363"/>
+        <source>Cannot read codeplug from file '%1': %2</source>
+        <translation>Не удалось прочитать кодплаг из файла «%1»: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="216"/>
+        <source>Cannot read codeplug.</source>
+        <translation>Не удалось прочитать кодплаг.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="267"/>
+        <source>Save codeplug</source>
+        <translation>Сохранить кодплаг</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="268"/>
+        <source>Codeplug Files (*.yaml *.yml)</source>
+        <translation>Файлы кодплага (*.yaml *.yml)</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="274"/>
+        <source>Please use new YAML format.</source>
+        <translation>Используйте новый формат YAML.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="275"/>
+        <source>Saving in the old table-based conf format was disabled with 0.9.0. Reading these files still works.</source>
+        <translation>Сохранение в старом табличном формате conf отключено с версии 0.9.0. Чтение таких файлов по-прежнему поддерживается.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="287"/>
+        <location filename="../src/application.cc" line="324"/>
+        <source>Cannot save codeplug to file '%1': %2</source>
+        <translation>Не удалось сохранить кодплаг в файл «%1»: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="296"/>
+        <source>Cannot save codeplug</source>
+        <translation>Не удалось сохранить кодплаг</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="297"/>
+        <source>Cannot save codeplug to file '%1'.</source>
+        <translation>Не удалось сохранить кодплаг в файл «%1».</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="314"/>
+        <source>Export codeplug</source>
+        <translation>Экспорт кодплага</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="315"/>
+        <source>CHIRP CSV Files (*.csv)</source>
+        <translation>Файлы CHIRP CSV (*.csv)</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="332"/>
+        <source>Cannot export codeplug</source>
+        <translation>Не удалось экспортировать кодплаг</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="333"/>
+        <source>Cannot export codeplug to file '%1':
+%2</source>
+        <translation>Не удалось экспортировать кодплаг в файл «%1»:
+%2</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="349"/>
+        <source>Import codeplug</source>
+        <translation>Импорт кодплага</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="350"/>
+        <source>CHIRP CSV Files (*.csv);;YAML Files (*.yaml *.yml)</source>
+        <translation>Файлы CHIRP CSV (*.csv);;Файлы YAML (*.yaml *.yml)</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="369"/>
+        <location filename="../src/application.cc" line="377"/>
+        <location filename="../src/application.cc" line="383"/>
+        <location filename="../src/application.cc" line="396"/>
+        <source>Cannot import codeplug</source>
+        <translation>Не удалось импортировать кодплаг</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="370"/>
+        <location filename="../src/application.cc" line="378"/>
+        <location filename="../src/application.cc" line="397"/>
+        <source>Cannot import codeplug from '%1': %2</source>
+        <translation>Не удалось импортировать кодплаг из «%1»: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="384"/>
+        <source>Do not know, how to handle file '%1'.</source>
+        <translation>Неизвестно, как обработать файл «%1».</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="418"/>
+        <source>No matching devices found.</source>
+        <translation>Подходящих устройств не найдено.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="444"/>
+        <source>Cannot connect to radio</source>
+        <translation>Не удалось подключиться к радиостанции</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="445"/>
+        <source>Cannot connect to radio: %1</source>
+        <translation>Не удалось подключиться к радиостанции: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="455"/>
+        <source>Radio found</source>
+        <translation>Радиостанция найдена</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="455"/>
+        <source>Found device '%1'.</source>
+        <translation>Найдено устройство «%1».</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="458"/>
+        <location filename="../src/application.cc" line="474"/>
+        <location filename="../src/application.cc" line="529"/>
+        <location filename="../src/application.cc" line="600"/>
+        <location filename="../src/application.cc" line="643"/>
+        <location filename="../src/application.cc" line="724"/>
+        <source>No radio found</source>
+        <translation>Радиостанция не найдена</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="499"/>
+        <source>Verification success</source>
+        <translation>Проверка пройдена</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="500"/>
+        <source>The codeplug was successfully verified with the radio '%1'</source>
+        <translation>Кодплаг совпадает с данными в радиостанции «%1»</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="544"/>
+        <source>Read ...</source>
+        <translation>Считать…</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="554"/>
+        <source>Read error</source>
+        <translation>Ошибка чтения</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="573"/>
+        <source>Read complete</source>
+        <translation>Чтение завершено</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="629"/>
+        <source>Upload ...</source>
+        <translation>Запись…</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="650"/>
+        <location filename="../src/application.cc" line="660"/>
+        <location filename="../src/application.cc" line="672"/>
+        <source>Cannot write call-sign DB.</source>
+        <translation>Не удалось записать базу позывных.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="651"/>
+        <source>The detected radio '%1' does not support a call-sign DB.</source>
+        <translation>Радиостанция «%1» не поддерживает базу позывных.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="459"/>
+        <location filename="../src/application.cc" line="475"/>
+        <location filename="../src/application.cc" line="530"/>
+        <location filename="../src/application.cc" line="601"/>
+        <location filename="../src/application.cc" line="644"/>
+        <location filename="../src/application.cc" line="725"/>
+        <source>No matching device was found.</source>
+        <translation>Подходящее устройство не найдено.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="661"/>
+        <source>The detected radio '%1' does support a call-sign DB. This feature, however, is not implemented yet.</source>
+        <translation>Радиостанция «%1» поддерживает базу позывных, но эта функция пока не реализована.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="673"/>
+        <source>QDMR selects the call-signs to be written based on the default DMR ID of the radio. No default ID set.</source>
+        <translation>QDMR подбирает позывные для записи по DMR ID радиостанции. DMR ID по умолчанию не задан.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="710"/>
+        <source>Write call-sign DB ...</source>
+        <translation>Запись базы позывных…</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="731"/>
+        <location filename="../src/application.cc" line="741"/>
+        <source>Cannot write satellite config.</source>
+        <translation>Не удалось записать конфигурацию спутников.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="732"/>
+        <source>The detected radio '%1' does not support satellite tracking.</source>
+        <translation>Радиостанция «%1» не поддерживает слежение за спутниками.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="742"/>
+        <source>The detected radio '%1' does support satellite tracking. This feature, however, is not implemented yet.</source>
+        <translation>Радиостанция «%1» поддерживает слежение за спутниками, но эта функция пока не реализована.</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="764"/>
+        <source>Write satellite config ...</source>
+        <translation>Запись конфигурации спутников…</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="783"/>
+        <source>Write error</source>
+        <translation>Ошибка записи</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="795"/>
+        <source>Write complete</source>
+        <translation>Запись завершена</translation>
+    </message>
+    <message>
+        <location filename="../src/application.cc" line="855"/>
+        <source>%1 (alias for %2 %3)</source>
+        <translation>%1 (псевдоним для %2 %3)</translation>
+    </message>
+</context>
+<context>
+    <name>BandwidthSelect</name>
+    <message>
+        <location filename="../src/bandwidthselect.cc" line="8"/>
+        <source>Narrow (12.5 kHz)</source>
+        <translation type="unfinished">Narrow (12.5 kHz)</translation>
+    </message>
+    <message>
+        <location filename="../src/bandwidthselect.cc" line="9"/>
+        <source>Wide (25 kHz)</source>
+        <translation type="unfinished">Wide (25 kHz)</translation>
+    </message>
+</context>
+<context>
+    <name>ChannelDialog</name>
+    <message>
+        <location filename="../src/channeldialog.ui" line="14"/>
+        <source>Edit Channel</source>
+        <translation>Изменить канал</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="23"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; qdmr provides some auto-completion for channels. That is, start typing the call-sign of a repeater. After three chars are entered, a request is sent to repeaterbook.com to retrieve matching repeaters. These requests may take some time. The results are stored locally in a cache.&lt;/p&gt;&lt;p&gt;A drop-down list will appear, allowing to select a repeater. Once one repeater is selected, the RX/TX frequencies and CTCSS tones are filled in (if applicable).&lt;/p&gt;&lt;p align="right"&gt;&lt;a href="#hide"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;hide&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; qdmr provides some auto-completion for channels. That is, start typing the call-sign of a repeater. After three chars are entered, a request is sent to repeaterbook.com to retrieve matching repeaters. These requests may take some time. The results are stored locally in a cache.&lt;/p&gt;&lt;p&gt;A drop-down list will appear, allowing to select a repeater. Once one repeater is selected, the RX/TX frequencies and CTCSS tones are filled in (if applicable).&lt;/p&gt;&lt;p align="right"&gt;&lt;a href="#hide"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;hide&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="40"/>
+        <source>Basic</source>
+        <translation>Основное</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="48"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="65"/>
+        <source>Rx Frequency</source>
+        <translation>Частота приёма</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="75"/>
+        <source>Tx Frequency</source>
+        <translation>Частота передачи</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="85"/>
+        <source>Tx Offset</source>
+        <translation type="unfinished">Tx Offset</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="137"/>
+        <source>Power</source>
+        <translation>Мощность</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="153"/>
+        <source>Max</source>
+        <translation>Макс.</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="158"/>
+        <source>High</source>
+        <translation>Высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="163"/>
+        <source>Mid</source>
+        <translation>Средняя</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="168"/>
+        <source>Low</source>
+        <translation>Низкая</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="173"/>
+        <source>Min</source>
+        <translation>Мин.</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="181"/>
+        <location filename="../src/channeldialog.ui" line="218"/>
+        <location filename="../src/channeldialog.ui" line="252"/>
+        <source>Default</source>
+        <translation>По умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="190"/>
+        <source>Tx Timeout</source>
+        <translation type="unfinished">Tx Timeout</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="205"/>
+        <location filename="../src/channeldialog.ui" line="242"/>
+        <source>Off</source>
+        <translation>Выкл.</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="227"/>
+        <source>VOX Level</source>
+        <translation type="unfinished">VOX Level</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="261"/>
+        <source>Rx Only</source>
+        <translation type="unfinished">Rx Only</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="271"/>
+        <source>Scan List</source>
+        <translation>Список сканирования</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.ui" line="301"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.cc" line="25"/>
+        <source>No offset</source>
+        <translation type="unfinished">No offset</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.cc" line="27"/>
+        <source>Positive offset</source>
+        <translation type="unfinished">Positive offset</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.cc" line="29"/>
+        <source>Negative offset</source>
+        <translation type="unfinished">Negative offset</translation>
+    </message>
+    <message>
+        <location filename="../src/channeldialog.cc" line="50"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+</context>
+<context>
+    <name>ChannelListView</name>
+    <message>
+        <location filename="../src/channellistview.cc" line="102"/>
+        <source>Select a single channel first</source>
+        <translation>Сначала выберите один канал</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.cc" line="103"/>
+        <source>To clone a channel, please select a single channel to clone.</source>
+        <translation>Чтобы клонировать канал, выберите один канал для клонирования.</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.cc" line="159"/>
+        <source>Cannot delete channel</source>
+        <translation>Не удалось удалить канал</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.cc" line="160"/>
+        <source>Cannot delete channel: You have to select a channel first.</source>
+        <translation>Не удалось удалить канал: сначала выберите канал.</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.cc" line="170"/>
+        <location filename="../src/channellistview.cc" line="174"/>
+        <source>Delete channel?</source>
+        <translation>Удалить канал?</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.cc" line="170"/>
+        <source>Delete channel %1?</source>
+        <translation>Удалить канал «%1»?</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.cc" line="174"/>
+        <source>Delete %1 channels?</source>
+        <translation>Удалить %1 каналов?</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.ui" line="35"/>
+        <source>Alt+A</source>
+        <translation type="unfinished">Alt+A</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.ui" line="32"/>
+        <source>Add Channel ...</source>
+        <translation>Добавить канал…</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.ui" line="42"/>
+        <source>Clone Channel</source>
+        <translation>Клонировать канал</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.ui" line="45"/>
+        <source>Alt+C</source>
+        <translation type="unfinished">Alt+C</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.ui" line="52"/>
+        <source>Delete Channel</source>
+        <translation>Удалить канал</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.ui" line="55"/>
+        <source>Alt+-</source>
+        <translation type="unfinished">Alt+-</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.ui" line="64"/>
+        <source>Add FM Channel</source>
+        <translation>Добавить FM-канал</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.ui" line="67"/>
+        <source>Adds a new FM channel</source>
+        <translation>Добавляет новый FM-канал</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.ui" line="75"/>
+        <source>Add DMR Channel</source>
+        <translation>Добавить DMR-канал</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.ui" line="78"/>
+        <source>Adds a new DMR channel.</source>
+        <translation>Добавляет новый DMR-канал.</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.ui" line="86"/>
+        <source>Add AM Channel</source>
+        <translation>Добавить AM-канал</translation>
+    </message>
+    <message>
+        <location filename="../src/channellistview.ui" line="89"/>
+        <source>Adds a new AM channel.</source>
+        <translation>Добавляет новый AM-канал.</translation>
+    </message>
+</context>
+<context>
+    <name>ChannelListWrapper</name>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="279"/>
+        <source>FM</source>
+        <translation>FM</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="277"/>
+        <source>DMR</source>
+        <translation>DMR</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="281"/>
+        <source>AM</source>
+        <translation>AM</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="292"/>
+        <location filename="../src/configitemwrapper.cc" line="303"/>
+        <location filename="../src/configitemwrapper.cc" line="381"/>
+        <location filename="../src/configitemwrapper.cc" line="407"/>
+        <location filename="../src/configitemwrapper.cc" line="418"/>
+        <location filename="../src/configitemwrapper.cc" line="425"/>
+        <source>[Default]</source>
+        <translation type="unfinished">[Default]</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="294"/>
+        <source>Max</source>
+        <translation>Макс.</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="295"/>
+        <source>High</source>
+        <translation>Высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="296"/>
+        <source>Mid</source>
+        <translation>Средняя</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="297"/>
+        <source>Low</source>
+        <translation>Низкая</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="298"/>
+        <source>Min</source>
+        <translation>Мин.</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="305"/>
+        <location filename="../src/configitemwrapper.cc" line="308"/>
+        <source>Off</source>
+        <translation>Выкл.</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="308"/>
+        <source>On</source>
+        <translation>Вкл.</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="312"/>
+        <location filename="../src/configitemwrapper.cc" line="318"/>
+        <source>Always</source>
+        <translation>Всегда</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="313"/>
+        <location filename="../src/configitemwrapper.cc" line="319"/>
+        <source>Free</source>
+        <translation>Свободно</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="314"/>
+        <source>Color</source>
+        <translation>Код цвета</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="320"/>
+        <source>Tone</source>
+        <translation>Тон</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="323"/>
+        <location filename="../src/configitemwrapper.cc" line="347"/>
+        <location filename="../src/configitemwrapper.cc" line="354"/>
+        <location filename="../src/configitemwrapper.cc" line="365"/>
+        <location filename="../src/configitemwrapper.cc" line="375"/>
+        <location filename="../src/configitemwrapper.cc" line="384"/>
+        <location filename="../src/configitemwrapper.cc" line="410"/>
+        <location filename="../src/configitemwrapper.cc" line="415"/>
+        <location filename="../src/configitemwrapper.cc" line="434"/>
+        <location filename="../src/configitemwrapper.cc" line="441"/>
+        <location filename="../src/configitemwrapper.cc" line="448"/>
+        <location filename="../src/configitemwrapper.cc" line="459"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="420"/>
+        <location filename="../src/configitemwrapper.cc" line="427"/>
+        <source>Open</source>
+        <translation>Открыть</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="451"/>
+        <source>Wide</source>
+        <translation>Широкая</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="453"/>
+        <source>Narrow</source>
+        <translation>Узкая</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="474"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="475"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="476"/>
+        <source>Rx Frequency</source>
+        <translation>Частота приёма</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="477"/>
+        <source>Tx Frequency</source>
+        <translation>Частота передачи</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="478"/>
+        <source>Power</source>
+        <translation>Мощность</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="479"/>
+        <source>Timeout</source>
+        <translation>Таймаут</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="480"/>
+        <source>Rx Only</source>
+        <translation type="unfinished">Rx Only</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="481"/>
+        <source>Admit</source>
+        <translation>Условие передачи</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="482"/>
+        <source>Scanlist</source>
+        <translation type="unfinished">Scanlist</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="484"/>
+        <source>CC</source>
+        <translation>CC</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="485"/>
+        <source>TS</source>
+        <translation>TS</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="486"/>
+        <source>RX Group List</source>
+        <translation type="unfinished">RX Group List</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="487"/>
+        <source>TX Contact</source>
+        <translation type="unfinished">TX Contact</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="488"/>
+        <source>DMR ID</source>
+        <translation>DMR ID</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="489"/>
+        <source>GPS/APRS</source>
+        <translation>GPS/APRS</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="490"/>
+        <source>Roaming</source>
+        <translation type="unfinished">Roaming</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="491"/>
+        <source>Squelch</source>
+        <translation>Шумоподавитель</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="492"/>
+        <source>Rx Tone</source>
+        <translation type="unfinished">Rx Tone</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="493"/>
+        <source>Tx Tone</source>
+        <translation type="unfinished">Tx Tone</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="495"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="483"/>
+        <source>Zones</source>
+        <translation>Зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="494"/>
+        <source>Bandwidth</source>
+        <translation>Полоса</translation>
+    </message>
+</context>
+<context>
+    <name>ChannelRefListWrapper</name>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="523"/>
+        <source>Channel</source>
+        <translation>Канал</translation>
+    </message>
+</context>
+<context>
+    <name>ChannelSelectionDialog</name>
+    <message>
+        <location filename="../src/channelselectiondialog.cc" line="24"/>
+        <source>Select a channel:</source>
+        <translation>Выберите канал:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigMergeDialog</name>
+    <message>
+        <location filename="../src/configmergedialog.ui" line="17"/>
+        <source>Merging codeplugs ...</source>
+        <translation type="unfinished">Merging codeplugs ...</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.ui" line="32"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Conflict resolution strategies:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If some of the imported objects (channels, contacts, ...) already exist, select how these conflicts are resolved for items and sets.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Conflict resolution strategies:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If some of the imported objects (channels, contacts, ...) already exist, select how these conflicts are resolved for items and sets.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.ui" line="48"/>
+        <source>Items are all atomic objects like radio IDs, channels, contacts and roaming channels.</source>
+        <translation type="unfinished">Items are all atomic objects like radio IDs, channels, contacts and roaming channels.</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.ui" line="51"/>
+        <source>Items</source>
+        <translation type="unfinished">Items</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.ui" line="58"/>
+        <location filename="../src/configmergedialog.ui" line="111"/>
+        <source>Ignore</source>
+        <translation type="unfinished">Ignore</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.ui" line="63"/>
+        <location filename="../src/configmergedialog.ui" line="116"/>
+        <source>Override</source>
+        <translation type="unfinished">Override</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.ui" line="68"/>
+        <location filename="../src/configmergedialog.ui" line="121"/>
+        <source>Duplicate</source>
+        <translation type="unfinished">Duplicate</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.ui" line="101"/>
+        <source>Sets are all objects, containing other elements like group lists, zones, scan lists and roaming zones.</source>
+        <translation type="unfinished">Sets are all objects, containing other elements like group lists, zones, scan lists and roaming zones.</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.ui" line="104"/>
+        <source>Sets</source>
+        <translation type="unfinished">Sets</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.ui" line="126"/>
+        <source>Merge</source>
+        <translation type="unfinished">Merge</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.cc" line="71"/>
+        <source>Ignores any duplicate item.</source>
+        <translation type="unfinished">Ignores any duplicate item.</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.cc" line="74"/>
+        <source>Replaces any duplicate item with the imported one.</source>
+        <translation type="unfinished">Replaces any duplicate item with the imported one.</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.cc" line="77"/>
+        <source>Imports any duplicate item with a modified name.</source>
+        <translation type="unfinished">Imports any duplicate item with a modified name.</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.cc" line="89"/>
+        <source>Ignores any duplicate set.</source>
+        <translation type="unfinished">Ignores any duplicate set.</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.cc" line="92"/>
+        <source>Replaces any duplicate set with the imported one.</source>
+        <translation type="unfinished">Replaces any duplicate set with the imported one.</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.cc" line="95"/>
+        <source>Imports any duplicate set with a modified name.</source>
+        <translation type="unfinished">Imports any duplicate set with a modified name.</translation>
+    </message>
+    <message>
+        <location filename="../src/configmergedialog.cc" line="98"/>
+        <source>Merges duplicate sets.</source>
+        <translation type="unfinished">Merges duplicate sets.</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigObjectListView</name>
+    <message>
+        <location filename="../src/configobjectlistview.cc" line="72"/>
+        <location filename="../src/configobjectlistview.cc" line="94"/>
+        <location filename="../src/configobjectlistview.cc" line="118"/>
+        <location filename="../src/configobjectlistview.cc" line="141"/>
+        <location filename="../src/configobjectlistview.cc" line="165"/>
+        <location filename="../src/configobjectlistview.cc" line="188"/>
+        <source>Cannot move items.</source>
+        <translation type="unfinished">Cannot move items.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjectlistview.cc" line="73"/>
+        <location filename="../src/configobjectlistview.cc" line="95"/>
+        <location filename="../src/configobjectlistview.cc" line="119"/>
+        <location filename="../src/configobjectlistview.cc" line="142"/>
+        <location filename="../src/configobjectlistview.cc" line="166"/>
+        <location filename="../src/configobjectlistview.cc" line="189"/>
+        <source>Cannot move items: You have to select at least one item first.</source>
+        <translation type="unfinished">Cannot move items: You have to select at least one item first.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjectlistview.ui" line="25"/>
+        <source>Move selected item(s) to the top.</source>
+        <translation type="unfinished">Move selected item(s) to the top.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjectlistview.ui" line="45"/>
+        <source>Move selected item(s) ten positions up.</source>
+        <translation type="unfinished">Move selected item(s) ten positions up.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjectlistview.ui" line="65"/>
+        <source>Move selected item(s) one position up.</source>
+        <translation type="unfinished">Move selected item(s) one position up.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjectlistview.ui" line="85"/>
+        <source>Move selected item(s) one position down.</source>
+        <translation type="unfinished">Move selected item(s) one position down.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjectlistview.ui" line="105"/>
+        <source>Move selected item(s) ten positions down.</source>
+        <translation type="unfinished">Move selected item(s) ten positions down.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjectlistview.ui" line="125"/>
+        <source>Move selected item(s) to the bottom.</source>
+        <translation type="unfinished">Move selected item(s) to the bottom.</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigObjectTableView</name>
+    <message>
+        <location filename="../src/configobjecttableview.cc" line="253"/>
+        <location filename="../src/configobjecttableview.cc" line="260"/>
+        <source>Cannot move items.</source>
+        <translation type="unfinished">Cannot move items.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttableview.cc" line="254"/>
+        <source>Cannot move items: You have to select at least one item first.</source>
+        <translation type="unfinished">Cannot move items: You have to select at least one item first.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttableview.cc" line="261"/>
+        <source>Cannot move items as long as there is some filter or sorting applied.</source>
+        <translation type="unfinished">Cannot move items as long as there is some filter or sorting applied.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttableview.ui" line="50"/>
+        <source>Move selected item(s) to the top.</source>
+        <translation type="unfinished">Move selected item(s) to the top.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttableview.ui" line="64"/>
+        <source>Move selected item(s) ten positions up.</source>
+        <translation type="unfinished">Move selected item(s) ten positions up.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttableview.ui" line="78"/>
+        <source>Move selected item(s) one position up.</source>
+        <translation type="unfinished">Move selected item(s) one position up.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttableview.ui" line="92"/>
+        <source>Move selected item(s) one position down.</source>
+        <translation type="unfinished">Move selected item(s) one position down.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttableview.ui" line="106"/>
+        <source>Move selected item(s) ten positions down.</source>
+        <translation type="unfinished">Move selected item(s) ten positions down.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttableview.ui" line="120"/>
+        <source>Move selected item(s) to the bottom.</source>
+        <translation type="unfinished">Move selected item(s) to the bottom.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttableview.ui" line="188"/>
+        <source>Toggle Filter and Sorting</source>
+        <translation type="unfinished">Toggle Filter and Sorting</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttableview.ui" line="199"/>
+        <source>Close Sort and Filter</source>
+        <translation type="unfinished">Close Sort and Filter</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigObjectTypeSelectionDialog</name>
+    <message>
+        <location filename="../src/configobjecttypeselectiondialog.cc" line="44"/>
+        <source>An instance of %1.</source>
+        <translation type="unfinished">An instance of %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttypeselectiondialog.cc" line="55"/>
+        <source>&lt;p&gt;%1&lt;p&gt;&lt;p style="margin-left:10px;"&gt;%2&lt;/p&gt;</source>
+        <translation type="unfinished">&lt;p&gt;%1&lt;p&gt;&lt;p style="margin-left:10px;"&gt;%2&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttypeselectiondialog.ui" line="20"/>
+        <source>Create extension object</source>
+        <translation type="unfinished">Create extension object</translation>
+    </message>
+    <message>
+        <location filename="../src/configobjecttypeselectiondialog.ui" line="26"/>
+        <source>Select the class of object to create</source>
+        <translation type="unfinished">Select the class of object to create</translation>
+    </message>
+</context>
+<context>
+    <name>ContactListView</name>
+    <message>
+        <location filename="../src/contactlistview.cc" line="83"/>
+        <source>Cannot delete contact</source>
+        <translation>Не удалось удалить контакт</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.cc" line="84"/>
+        <source>Cannot delete contact: You have to select a contact first.</source>
+        <translation>Не удалось удалить контакт: сначала выберите контакт.</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.cc" line="94"/>
+        <source>Delete contact?</source>
+        <translation>Удалить контакт?</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.cc" line="94"/>
+        <source>Delete contact %1?</source>
+        <translation>Удалить контакт «%1»?</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.cc" line="98"/>
+        <source>Delete contacts?</source>
+        <translation>Удалить контакты?</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.cc" line="98"/>
+        <source>Delete %1 contacts?</source>
+        <translation>Удалить %1 контактов?</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.ui" line="32"/>
+        <source>Adds a contact to the list.</source>
+        <translation type="unfinished">Adds a contact to the list.</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.ui" line="38"/>
+        <source>Alt++</source>
+        <translation type="unfinished">Alt++</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.ui" line="60"/>
+        <source>Add M17 Contact</source>
+        <translation>Добавить контакт M17</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.ui" line="63"/>
+        <source>Adds an M17 contact to the list.</source>
+        <translation type="unfinished">Adds an M17 contact to the list.</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.ui" line="68"/>
+        <source>Add DTMF Contact</source>
+        <translation>Добавить DTMF-контакт</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.ui" line="71"/>
+        <source>Adds an DTMF (analog) contact to the list.</source>
+        <translation type="unfinished">Adds an DTMF (analog) contact to the list.</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.ui" line="76"/>
+        <source>Add DMR Contact</source>
+        <translation>Добавить DMR-контакт</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.ui" line="79"/>
+        <source>Adds an DMR contact to the list.</source>
+        <translation type="unfinished">Adds an DMR contact to the list.</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.ui" line="45"/>
+        <source>Delete contact button</source>
+        <translation type="unfinished">Delete contact button</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.ui" line="35"/>
+        <source>Add Contact</source>
+        <translation>Добавить контакт</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.ui" line="48"/>
+        <source>Delete Contact</source>
+        <translation>Удалить контакт</translation>
+    </message>
+    <message>
+        <location filename="../src/contactlistview.ui" line="51"/>
+        <source>Alt+-</source>
+        <translation type="unfinished">Alt+-</translation>
+    </message>
+</context>
+<context>
+    <name>ContactListWrapper</name>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="657"/>
+        <source>DTMF</source>
+        <translation type="unfinished">DTMF</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="663"/>
+        <location filename="../src/configitemwrapper.cc" line="684"/>
+        <location filename="../src/configitemwrapper.cc" line="706"/>
+        <source>On</source>
+        <translation>Вкл.</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="663"/>
+        <location filename="../src/configitemwrapper.cc" line="684"/>
+        <location filename="../src/configitemwrapper.cc" line="706"/>
+        <source>Off</source>
+        <translation>Выкл.</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="674"/>
+        <source>Private Call</source>
+        <translation>Индивидуальный вызов</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="675"/>
+        <source>Group Call</source>
+        <translation>Групповой вызов</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="676"/>
+        <source>All Call</source>
+        <translation>Общий вызов</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="688"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="698"/>
+        <source>M17</source>
+        <translation>M17</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="703"/>
+        <source>[Broadcast]</source>
+        <translation type="unfinished">[Broadcast]</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="723"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="725"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="727"/>
+        <source>Number</source>
+        <translation type="unfinished">Number</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="729"/>
+        <source>RX Tone</source>
+        <translation type="unfinished">RX Tone</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="731"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+</context>
+<context>
+    <name>DMRAdmitSelect</name>
+    <message>
+        <location filename="../src/admitselect.cc" line="35"/>
+        <source>Always</source>
+        <translation>Всегда</translation>
+    </message>
+    <message>
+        <location filename="../src/admitselect.cc" line="36"/>
+        <source>Channel Free</source>
+        <translation>Канал свободен</translation>
+    </message>
+    <message>
+        <location filename="../src/admitselect.cc" line="37"/>
+        <source>Other Color-code</source>
+        <translation>Чужой цветовой код</translation>
+    </message>
+</context>
+<context>
+    <name>DMRChannelDialog</name>
+    <message>
+        <location filename="../src/dmrchanneldialog.cc" line="36"/>
+        <source>Radio Id</source>
+        <translation type="unfinished">Radio Id</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrchanneldialog.cc" line="38"/>
+        <source>Tx Admit</source>
+        <translation type="unfinished">Tx Admit</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrchanneldialog.cc" line="40"/>
+        <source>Color-code</source>
+        <translation type="unfinished">Color-code</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrchanneldialog.cc" line="43"/>
+        <source>Time-slot</source>
+        <translation type="unfinished">Time-slot</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrchanneldialog.cc" line="45"/>
+        <source>Group list</source>
+        <translation type="unfinished">Group list</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrchanneldialog.cc" line="47"/>
+        <source>Tx Contact</source>
+        <translation type="unfinished">Tx Contact</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrchanneldialog.cc" line="49"/>
+        <source>APRS</source>
+        <translation>APRS</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrchanneldialog.cc" line="51"/>
+        <source>Roaming zone</source>
+        <translation type="unfinished">Roaming zone</translation>
+    </message>
+</context>
+<context>
+    <name>DMRContactDialog</name>
+    <message>
+        <location filename="../src/dmrcontactdialog.cc" line="27"/>
+        <source>Create DMR Contact</source>
+        <translation>Создать DMR-контакт</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrcontactdialog.cc" line="52"/>
+        <source>Edit DMR Contact</source>
+        <translation>Изменить DMR-контакт</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrcontactdialog.cc" line="83"/>
+        <source>Private Call</source>
+        <translation>Индивидуальный вызов</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrcontactdialog.cc" line="84"/>
+        <source>Group Call</source>
+        <translation>Групповой вызов</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrcontactdialog.cc" line="85"/>
+        <source>All Call</source>
+        <translation>Общий вызов</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrcontactdialog.ui" line="30"/>
+        <source>Basic</source>
+        <translation>Основное</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrcontactdialog.ui" line="36"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrcontactdialog.ui" line="53"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrcontactdialog.ui" line="63"/>
+        <source>Number</source>
+        <translation type="unfinished">Number</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrcontactdialog.ui" line="73"/>
+        <source>Ring</source>
+        <translation type="unfinished">Ring</translation>
+    </message>
+    <message>
+        <location filename="../src/dmrcontactdialog.ui" line="84"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+</context>
+<context>
+    <name>DMRContactSelect</name>
+    <message>
+        <location filename="../src/dmrcontactdialog.cc" line="181"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+</context>
+<context>
+    <name>DMRIDDialog</name>
+    <message>
+        <location filename="../src/dmriddialog.ui" line="30"/>
+        <source>Basic</source>
+        <translation>Основное</translation>
+    </message>
+    <message>
+        <location filename="../src/dmriddialog.ui" line="36"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/dmriddialog.ui" line="46"/>
+        <source>DMR ID</source>
+        <translation>DMR ID</translation>
+    </message>
+    <message>
+        <location filename="../src/dmriddialog.ui" line="57"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+</context>
+<context>
+    <name>DMRIdSelect</name>
+    <message>
+        <location filename="../src/idselect.cc" line="9"/>
+        <source>[Default]</source>
+        <translation type="unfinished">[Default]</translation>
+    </message>
+</context>
+<context>
+    <name>DTMFContactDialog</name>
+    <message>
+        <location filename="../src/dtmfcontactdialog.cc" line="12"/>
+        <source>Create DTMF Contact</source>
+        <translation>Создать DTMF-контакт</translation>
+    </message>
+    <message>
+        <location filename="../src/dtmfcontactdialog.cc" line="20"/>
+        <source>Edit DMR Contact</source>
+        <translation>Изменить DMR-контакт</translation>
+    </message>
+    <message>
+        <location filename="../src/dtmfcontactdialog.ui" line="30"/>
+        <source>Basic</source>
+        <translation>Основное</translation>
+    </message>
+    <message>
+        <location filename="../src/dtmfcontactdialog.ui" line="36"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/dtmfcontactdialog.ui" line="46"/>
+        <source>Number</source>
+        <translation type="unfinished">Number</translation>
+    </message>
+    <message>
+        <location filename="../src/dtmfcontactdialog.ui" line="56"/>
+        <source>Ring</source>
+        <translation type="unfinished">Ring</translation>
+    </message>
+    <message>
+        <location filename="../src/dtmfcontactdialog.ui" line="67"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceSelectionDialog</name>
+    <message>
+        <location filename="../src/deviceselectiondialog.ui" line="14"/>
+        <source>Select a device</source>
+        <translation type="unfinished">Select a device</translation>
+    </message>
+    <message>
+        <location filename="../src/deviceselectiondialog.ui" line="20"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;There is either more than one device detected or the one found is not considered save to access. Either way, select the device to use.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;There is either more than one device detected or the one found is not considered save to access. Either way, select the device to use.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>ErrorMessageView</name>
+    <message>
+        <location filename="../src/errormessageview.cc" line="12"/>
+        <source>Error: Unknown.</source>
+        <translation type="unfinished">Error: Unknown.</translation>
+    </message>
+    <message>
+        <location filename="../src/errormessageview.cc" line="18"/>
+        <source>Error: %1</source>
+        <translation type="unfinished">Error: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/errormessageview.ui" line="30"/>
+        <source>Traceback:</source>
+        <translation type="unfinished">Traceback:</translation>
+    </message>
+</context>
+<context>
+    <name>ExtensionView</name>
+    <message>
+        <location filename="../src/extensionview.cc" line="110"/>
+        <source>Cannot create extension.</source>
+        <translation type="unfinished">Cannot create extension.</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionview.cc" line="111"/>
+        <source>Cannot create extension, consider reporting a bug.</source>
+        <translation type="unfinished">Cannot create extension, consider reporting a bug.</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionview.cc" line="114"/>
+        <source>Cannot create list element.</source>
+        <translation type="unfinished">Cannot create list element.</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionview.cc" line="115"/>
+        <source>Cannot create list element, consider reporting a bug.</source>
+        <translation type="unfinished">Cannot create list element, consider reporting a bug.</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionview.ui" line="25"/>
+        <source>Create</source>
+        <translation>Создать</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionview.ui" line="32"/>
+        <source>Remove</source>
+        <translation>Удалить</translation>
+    </message>
+</context>
+<context>
+    <name>FMAPRSSelect</name>
+    <message>
+        <location filename="../src/aprsselect.cc" line="11"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+</context>
+<context>
+    <name>FMAPRSSystem</name>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="7"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="8"/>
+        <source>Police station</source>
+        <translation type="unfinished">Police station</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="9"/>
+        <source>Digipeater</source>
+        <translation type="unfinished">Digipeater</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="10"/>
+        <source>Phone</source>
+        <translation type="unfinished">Phone</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="11"/>
+        <source>DX cluster</source>
+        <translation type="unfinished">DX cluster</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="12"/>
+        <source>HF gateway</source>
+        <translation type="unfinished">HF gateway</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="13"/>
+        <source>Plane small</source>
+        <translation type="unfinished">Plane small</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="14"/>
+        <source>Mobile Satellite station</source>
+        <translation type="unfinished">Mobile Satellite station</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="15"/>
+        <source>Wheel Chair</source>
+        <translation type="unfinished">Wheel Chair</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="16"/>
+        <source>Snowmobile</source>
+        <translation type="unfinished">Snowmobile</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="17"/>
+        <source>Red cross</source>
+        <translation type="unfinished">Red cross</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="18"/>
+        <source>Boy scout</source>
+        <translation type="unfinished">Boy scout</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="19"/>
+        <source>Home</source>
+        <translation type="unfinished">Home</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="20"/>
+        <source>X</source>
+        <translation type="unfinished">X</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="21"/>
+        <source>Red dot</source>
+        <translation type="unfinished">Red dot</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="22"/>
+        <source>Circle 0</source>
+        <translation type="unfinished">Circle 0</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="23"/>
+        <source>Circle 1</source>
+        <translation type="unfinished">Circle 1</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="24"/>
+        <source>Circle 2</source>
+        <translation type="unfinished">Circle 2</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="25"/>
+        <source>Circle 3</source>
+        <translation type="unfinished">Circle 3</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="26"/>
+        <source>Circle 4</source>
+        <translation type="unfinished">Circle 4</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="27"/>
+        <source>Circle 5</source>
+        <translation type="unfinished">Circle 5</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="28"/>
+        <source>Circle 6</source>
+        <translation type="unfinished">Circle 6</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="29"/>
+        <source>Circle 7</source>
+        <translation type="unfinished">Circle 7</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="30"/>
+        <source>Circle 8</source>
+        <translation type="unfinished">Circle 8</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="31"/>
+        <source>Circle 9</source>
+        <translation type="unfinished">Circle 9</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="32"/>
+        <source>Fire</source>
+        <translation type="unfinished">Fire</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="33"/>
+        <source>Campground</source>
+        <translation type="unfinished">Campground</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="34"/>
+        <source>Motorcycle</source>
+        <translation type="unfinished">Motorcycle</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="35"/>
+        <source>Rail engine</source>
+        <translation type="unfinished">Rail engine</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="36"/>
+        <source>Car</source>
+        <translation type="unfinished">Car</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="37"/>
+        <source>File server</source>
+        <translation type="unfinished">File server</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="38"/>
+        <source>HC Future</source>
+        <translation type="unfinished">HC Future</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="39"/>
+        <source>Aid station</source>
+        <translation type="unfinished">Aid station</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="40"/>
+        <source>BBS</source>
+        <translation type="unfinished">BBS</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="41"/>
+        <source>Canoe</source>
+        <translation type="unfinished">Canoe</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="42"/>
+        <source>Eyeball</source>
+        <translation type="unfinished">Eyeball</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="43"/>
+        <source>Tractor</source>
+        <translation type="unfinished">Tractor</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="44"/>
+        <source>Grid Square</source>
+        <translation type="unfinished">Grid Square</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="45"/>
+        <source>Hotel</source>
+        <translation type="unfinished">Hotel</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="46"/>
+        <source>TCP/IP</source>
+        <translation type="unfinished">TCP/IP</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="47"/>
+        <source>School</source>
+        <translation type="unfinished">School</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="48"/>
+        <source>Logon</source>
+        <translation type="unfinished">Logon</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="49"/>
+        <source>MacOS</source>
+        <translation type="unfinished">MacOS</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="50"/>
+        <source>NTS station</source>
+        <translation type="unfinished">NTS station</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="51"/>
+        <source>Balloon</source>
+        <translation type="unfinished">Balloon</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="52"/>
+        <source>Police car</source>
+        <translation type="unfinished">Police car</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="53"/>
+        <source>TBD</source>
+        <translation type="unfinished">TBD</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="54"/>
+        <source>RV</source>
+        <translation type="unfinished">RV</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="55"/>
+        <source>Shuttle</source>
+        <translation type="unfinished">Shuttle</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="56"/>
+        <source>SSTV</source>
+        <translation type="unfinished">SSTV</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="57"/>
+        <source>Bus</source>
+        <translation type="unfinished">Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="58"/>
+        <source>ATV</source>
+        <translation type="unfinished">ATV</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="59"/>
+        <source>Weather service</source>
+        <translation type="unfinished">Weather service</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="60"/>
+        <source>Helo</source>
+        <translation type="unfinished">Helo</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="61"/>
+        <source>Yacht</source>
+        <translation type="unfinished">Yacht</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="62"/>
+        <source>MS Windows</source>
+        <translation type="unfinished">MS Windows</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="63"/>
+        <source>Jogger</source>
+        <translation type="unfinished">Jogger</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="64"/>
+        <source>Triangle</source>
+        <translation type="unfinished">Triangle</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="65"/>
+        <source>PBBS</source>
+        <translation type="unfinished">PBBS</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="66"/>
+        <source>Plane large</source>
+        <translation type="unfinished">Plane large</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="67"/>
+        <source>Weather station</source>
+        <translation type="unfinished">Weather station</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="68"/>
+        <source>Dish antenna</source>
+        <translation type="unfinished">Dish antenna</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="69"/>
+        <source>Ambulance</source>
+        <translation type="unfinished">Ambulance</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="70"/>
+        <source>Bike</source>
+        <translation type="unfinished">Bike</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="71"/>
+        <source>ICP</source>
+        <translation type="unfinished">ICP</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="72"/>
+        <source>Fire station</source>
+        <translation type="unfinished">Fire station</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="73"/>
+        <source>Horse</source>
+        <translation type="unfinished">Horse</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="74"/>
+        <source>Fire truck</source>
+        <translation type="unfinished">Fire truck</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="75"/>
+        <source>Glider</source>
+        <translation type="unfinished">Glider</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="76"/>
+        <source>Hospital</source>
+        <translation type="unfinished">Hospital</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="77"/>
+        <source>IOTA</source>
+        <translation type="unfinished">IOTA</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="78"/>
+        <source>Jeep</source>
+        <translation type="unfinished">Jeep</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="79"/>
+        <source>Truck small</source>
+        <translation type="unfinished">Truck small</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="80"/>
+        <source>Laptop</source>
+        <translation type="unfinished">Laptop</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="81"/>
+        <source>Mic-E</source>
+        <translation type="unfinished">Mic-E</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="82"/>
+        <source>Node</source>
+        <translation type="unfinished">Node</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="83"/>
+        <source>EOC</source>
+        <translation type="unfinished">EOC</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="84"/>
+        <source>Rover</source>
+        <translation type="unfinished">Rover</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="85"/>
+        <source>Grid</source>
+        <translation type="unfinished">Grid</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="86"/>
+        <source>Antenna</source>
+        <translation type="unfinished">Antenna</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="87"/>
+        <source>Power boat</source>
+        <translation type="unfinished">Power boat</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="88"/>
+        <source>Truck stop</source>
+        <translation type="unfinished">Truck stop</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="89"/>
+        <source>Truck large</source>
+        <translation type="unfinished">Truck large</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="90"/>
+        <source>Van</source>
+        <translation type="unfinished">Van</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="91"/>
+        <source>Water</source>
+        <translation type="unfinished">Water</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="92"/>
+        <source>XAPRS</source>
+        <translation type="unfinished">XAPRS</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="93"/>
+        <source>Yagi</source>
+        <translation type="unfinished">Yagi</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.cc" line="94"/>
+        <source>Shelter</source>
+        <translation type="unfinished">Shelter</translation>
+    </message>
+</context>
+<context>
+    <name>FMAdmitSelect</name>
+    <message>
+        <location filename="../src/admitselect.cc" line="9"/>
+        <source>Always</source>
+        <translation>Всегда</translation>
+    </message>
+    <message>
+        <location filename="../src/admitselect.cc" line="10"/>
+        <source>Channel Free</source>
+        <translation>Канал свободен</translation>
+    </message>
+    <message>
+        <location filename="../src/admitselect.cc" line="11"/>
+        <source>Other Tone</source>
+        <translation>Чужой тон</translation>
+    </message>
+</context>
+<context>
+    <name>FMChannelDialog</name>
+    <message>
+        <location filename="../src/fmchanneldialog.cc" line="32"/>
+        <source>Squelch</source>
+        <translation>Шумоподавитель</translation>
+    </message>
+    <message>
+        <location filename="../src/fmchanneldialog.cc" line="34"/>
+        <source>Tx Admit</source>
+        <translation type="unfinished">Tx Admit</translation>
+    </message>
+    <message>
+        <location filename="../src/fmchanneldialog.cc" line="36"/>
+        <source>Rx Tone</source>
+        <translation type="unfinished">Rx Tone</translation>
+    </message>
+    <message>
+        <location filename="../src/fmchanneldialog.cc" line="38"/>
+        <source>Tx Tone</source>
+        <translation type="unfinished">Tx Tone</translation>
+    </message>
+    <message>
+        <location filename="../src/fmchanneldialog.cc" line="40"/>
+        <source>Bandwidth</source>
+        <translation>Полоса</translation>
+    </message>
+    <message>
+        <location filename="../src/fmchanneldialog.cc" line="42"/>
+        <source>APRS</source>
+        <translation>APRS</translation>
+    </message>
+</context>
+<context>
+    <name>FlagEditDialog</name>
+    <message>
+        <location filename="../src/flageditdialog.ui" line="14"/>
+        <source>Select Flags</source>
+        <translation type="unfinished">Select Flags</translation>
+    </message>
+</context>
+<context>
+    <name>GPSSystemDialog</name>
+    <message>
+        <location filename="../src/gpssystemdialog.cc" line="8"/>
+        <source>Create DMR APRS System</source>
+        <translation>Создать DMR-систему APRS</translation>
+    </message>
+    <message>
+        <location filename="../src/gpssystemdialog.cc" line="15"/>
+        <source>Edit DMR APRS System</source>
+        <translation>Изменить DMR-систему APRS</translation>
+    </message>
+    <message>
+        <location filename="../src/gpssystemdialog.cc" line="46"/>
+        <source>[Selected]</source>
+        <translation type="unfinished">[Selected]</translation>
+    </message>
+    <message>
+        <location filename="../src/gpssystemdialog.ui" line="20"/>
+        <source>Edit GPS System</source>
+        <translation type="unfinished">Edit GPS System</translation>
+    </message>
+    <message>
+        <location filename="../src/gpssystemdialog.ui" line="30"/>
+        <source>Basic</source>
+        <translation>Основное</translation>
+    </message>
+    <message>
+        <location filename="../src/gpssystemdialog.ui" line="36"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/gpssystemdialog.ui" line="56"/>
+        <source>Destination</source>
+        <translation type="unfinished">Destination</translation>
+    </message>
+    <message>
+        <location filename="../src/gpssystemdialog.ui" line="63"/>
+        <source>Update period</source>
+        <translation type="unfinished">Update period</translation>
+    </message>
+    <message>
+        <location filename="../src/gpssystemdialog.ui" line="89"/>
+        <source>Revert Channel</source>
+        <translation type="unfinished">Revert Channel</translation>
+    </message>
+    <message>
+        <location filename="../src/gpssystemdialog.ui" line="107"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+</context>
+<context>
+    <name>GeneralSettingsView</name>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="22"/>
+        <source>Boot Settings</source>
+        <translation>Параметры загрузки</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="28"/>
+        <source>Intro Line 1</source>
+        <translation type="unfinished">Intro Line 1</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="35"/>
+        <source>First greeting line (if supported by the radio).</source>
+        <translation type="unfinished">First greeting line (if supported by the radio).</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="38"/>
+        <source>Intro line 1</source>
+        <translation type="unfinished">Intro line 1</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="45"/>
+        <source>Intro Line 2</source>
+        <translation type="unfinished">Intro Line 2</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="52"/>
+        <source>Second greeting line (if supported by the radio).</source>
+        <translation type="unfinished">Second greeting line (if supported by the radio).</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="58"/>
+        <source>Intro line 2</source>
+        <translation type="unfinished">Intro line 2</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="68"/>
+        <source>Audio Settings</source>
+        <translation>Аудио</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="74"/>
+        <source>MIC Amp.</source>
+        <translation>Усиление МК</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="91"/>
+        <source>Speech Synthesis</source>
+        <translation>Синтез речи</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="108"/>
+        <source>Channel Default Values</source>
+        <translation>Значения канала по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="114"/>
+        <source>Power</source>
+        <translation>Мощность</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="122"/>
+        <source>Max</source>
+        <translation>Макс.</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="127"/>
+        <source>High</source>
+        <translation>Высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="132"/>
+        <source>Mid</source>
+        <translation>Средняя</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="137"/>
+        <source>Low</source>
+        <translation>Низкая</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="142"/>
+        <source>Min</source>
+        <translation>Мин.</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="150"/>
+        <source>Squelch</source>
+        <translation>Шумоподавитель</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="157"/>
+        <source>Open</source>
+        <translation>Открыть</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="167"/>
+        <source>Transmit Timeout</source>
+        <translation>Таймаут передачи</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="174"/>
+        <location filename="../src/generalsettingsview.ui" line="194"/>
+        <source>Off</source>
+        <translation>Выкл.</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="187"/>
+        <source>VOX Level</source>
+        <translation type="unfinished">VOX Level</translation>
+    </message>
+    <message>
+        <location filename="../src/generalsettingsview.ui" line="211"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+</context>
+<context>
+    <name>GroupListWrapper</name>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="935"/>
+        <source>Contact</source>
+        <translation>Контакт</translation>
+    </message>
+</context>
+<context>
+    <name>GroupListsView</name>
+    <message>
+        <location filename="../src/grouplistsview.cc" line="46"/>
+        <source>Cannot delete RX group list</source>
+        <translation>Не удалось удалить групповой список</translation>
+    </message>
+    <message>
+        <location filename="../src/grouplistsview.cc" line="47"/>
+        <source>Cannot delete RX group lists: You have to select a group list first.</source>
+        <translation>Не удалось удалить групповые списки: сначала выберите список.</translation>
+    </message>
+    <message>
+        <location filename="../src/grouplistsview.cc" line="56"/>
+        <location filename="../src/grouplistsview.cc" line="60"/>
+        <source>Delete RX group list?</source>
+        <translation>Удалить групповой список?</translation>
+    </message>
+    <message>
+        <location filename="../src/grouplistsview.cc" line="56"/>
+        <source>Delete RX group list %1?</source>
+        <translation>Удалить групповой список «%1»?</translation>
+    </message>
+    <message>
+        <location filename="../src/grouplistsview.cc" line="60"/>
+        <source>Delete %1 RX group lists?</source>
+        <translation>Удалить %1 групповых списков?</translation>
+    </message>
+    <message>
+        <location filename="../src/grouplistsview.ui" line="32"/>
+        <source>Add RX Group</source>
+        <translation>Добавить групповой список</translation>
+    </message>
+    <message>
+        <location filename="../src/grouplistsview.ui" line="35"/>
+        <source>Alt++</source>
+        <translation type="unfinished">Alt++</translation>
+    </message>
+    <message>
+        <location filename="../src/grouplistsview.ui" line="42"/>
+        <source>Delete RX Group</source>
+        <translation>Удалить групповой список</translation>
+    </message>
+    <message>
+        <location filename="../src/grouplistsview.ui" line="45"/>
+        <source>Alt+-</source>
+        <translation type="unfinished">Alt+-</translation>
+    </message>
+</context>
+<context>
+    <name>GroupListsWrapper</name>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="911"/>
+        <source>RX Group Lists</source>
+        <translation>Групповые списки</translation>
+    </message>
+</context>
+<context>
+    <name>M17ChannelDialog</name>
+    <message>
+        <location filename="../src/m17channeldialog.cc" line="47"/>
+        <source>Channel mode</source>
+        <translation type="unfinished">Channel mode</translation>
+    </message>
+    <message>
+        <location filename="../src/m17channeldialog.cc" line="49"/>
+        <source>Access number</source>
+        <translation type="unfinished">Access number</translation>
+    </message>
+    <message>
+        <location filename="../src/m17channeldialog.cc" line="52"/>
+        <source>Tx contact</source>
+        <translation type="unfinished">Tx contact</translation>
+    </message>
+    <message>
+        <location filename="../src/m17channeldialog.cc" line="54"/>
+        <source>Send position</source>
+        <translation type="unfinished">Send position</translation>
+    </message>
+</context>
+<context>
+    <name>M17ChannelModeSelect</name>
+    <message>
+        <location filename="../src/m17channeldialog.cc" line="15"/>
+        <source>Voice</source>
+        <translation>Речь</translation>
+    </message>
+    <message>
+        <location filename="../src/m17channeldialog.cc" line="16"/>
+        <source>Data</source>
+        <translation>Данные</translation>
+    </message>
+    <message>
+        <location filename="../src/m17channeldialog.cc" line="17"/>
+        <source>Voice + Data</source>
+        <translation type="unfinished">Voice + Data</translation>
+    </message>
+</context>
+<context>
+    <name>M17ContactDialog</name>
+    <message>
+        <location filename="../src/m17contactdialog.ui" line="14"/>
+        <location filename="../src/m17contactdialog.cc" line="43"/>
+        <source>Edit M17 Contact</source>
+        <translation>Изменить контакт M17</translation>
+    </message>
+    <message>
+        <location filename="../src/m17contactdialog.ui" line="24"/>
+        <source>Basic</source>
+        <translation>Основное</translation>
+    </message>
+    <message>
+        <location filename="../src/m17contactdialog.ui" line="30"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/m17contactdialog.ui" line="37"/>
+        <source>The name of the contact.</source>
+        <translation type="unfinished">The name of the contact.</translation>
+    </message>
+    <message>
+        <location filename="../src/m17contactdialog.ui" line="44"/>
+        <source>Call</source>
+        <translation type="unfinished">Call</translation>
+    </message>
+    <message>
+        <location filename="../src/m17contactdialog.ui" line="51"/>
+        <source>The callsign of the contact. Must be not longer than 9 chars, A-Z, 0-9, ., /, -.</source>
+        <translation type="unfinished">The callsign of the contact. Must be not longer than 9 chars, A-Z, 0-9, ., /, -.</translation>
+    </message>
+    <message>
+        <location filename="../src/m17contactdialog.ui" line="58"/>
+        <source>Ring</source>
+        <translation type="unfinished">Ring</translation>
+    </message>
+    <message>
+        <location filename="../src/m17contactdialog.ui" line="68"/>
+        <source>Broadcast</source>
+        <translation type="unfinished">Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/m17contactdialog.ui" line="75"/>
+        <source>Sets this contact to be the M17 broadcast contact, the specified call is then ignored.</source>
+        <translation type="unfinished">Sets this contact to be the M17 broadcast contact, the specified call is then ignored.</translation>
+    </message>
+    <message>
+        <location filename="../src/m17contactdialog.ui" line="86"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+    <message>
+        <location filename="../src/m17contactdialog.cc" line="49"/>
+        <source>Create M17 Contact</source>
+        <translation>Создать контакт M17</translation>
+    </message>
+</context>
+<context>
+    <name>M17ContactSelect</name>
+    <message>
+        <location filename="../src/m17contactdialog.cc" line="94"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/mainwindow.ui" line="74"/>
+        <source>File</source>
+        <translation>Файл</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="86"/>
+        <source>Device</source>
+        <translation>Устройство</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="98"/>
+        <location filename="../src/mainwindow.ui" line="266"/>
+        <source>Help</source>
+        <translation>Справка</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="105"/>
+        <source>Databases</source>
+        <translation>Базы данных</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="127"/>
+        <source>Toolbar</source>
+        <translation>Панель инструментов</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="155"/>
+        <source>New</source>
+        <translation>Создать</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="158"/>
+        <source>Creates a new Codeplug.</source>
+        <translation>Создаёт новый кодплаг.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="161"/>
+        <source>Ctrl+N</source>
+        <translation type="unfinished">Ctrl+N</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="169"/>
+        <source>Open ...</source>
+        <translation>Открыть…</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="172"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Imports a codeplug from &amp;quot;conf&amp;quot; files.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Imports a codeplug from &amp;quot;conf&amp;quot; files.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="175"/>
+        <source>Ctrl+O</source>
+        <translation type="unfinished">Ctrl+O</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="183"/>
+        <source>Save ...</source>
+        <translation>Сохранить…</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="186"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saves the codeplug in a &amp;quot;conf&amp;quot; file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saves the codeplug in a &amp;quot;conf&amp;quot; file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="189"/>
+        <source>Ctrl+S</source>
+        <translation type="unfinished">Ctrl+S</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="197"/>
+        <source>Quit</source>
+        <translation>Выход</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="200"/>
+        <source>Quits the application.</source>
+        <translation>Завершает работу приложения.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="203"/>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished">Ctrl+Q</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="211"/>
+        <source>Detect</source>
+        <translation>Найти устройство</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="214"/>
+        <source>Detect connected radios.</source>
+        <translation>Найти подключённые радиостанции.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="222"/>
+        <source>Verify</source>
+        <translation>Проверить</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="225"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Verifies the current codeplug with connected radios.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Verifies the current codeplug with connected radios.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="228"/>
+        <source>Ctrl+R</source>
+        <translation type="unfinished">Ctrl+R</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="236"/>
+        <source>Read</source>
+        <translation>Считать</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="239"/>
+        <source>Reads a codeplug from connected radios.</source>
+        <translation>Считывает кодплаг из подключённой радиостанции.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="247"/>
+        <source>Write</source>
+        <translation>Записать</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="250"/>
+        <source>Writes the codeplug to the connected radio.</source>
+        <translation>Записывает кодплаг в подключённую радиостанцию.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="258"/>
+        <source>About qdmr</source>
+        <translation>О программе qdmr</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="269"/>
+        <source>Read the handbook.</source>
+        <translation>Открыть руководство.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="272"/>
+        <source>F1</source>
+        <translation type="unfinished">F1</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="280"/>
+        <location filename="../src/mainwindow.cc" line="107"/>
+        <source>Settings</source>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="283"/>
+        <source>Shows settings dialog</source>
+        <translation>Показать окно настроек</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="291"/>
+        <source>Write Callsign DB</source>
+        <translation>Записать базу позывных</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="294"/>
+        <source>Writes call-sign DB to radio.</source>
+        <translation>Записывает базу позывных в радиостанцию.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="299"/>
+        <source>Refresh Callsign DB</source>
+        <translation>Обновить базу позывных</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="302"/>
+        <source>Refreshes the downloaded callsign DB</source>
+        <translation>Обновляет загруженную базу позывных</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="310"/>
+        <source>Refresh Talkgroup DB</source>
+        <translation>Обновить БД токгрупп</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="313"/>
+        <source>Refreshes the downloaded talkgroup DB</source>
+        <translation>Обновляет загруженную базу токгрупп</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="318"/>
+        <source>Export to CHIRP ...</source>
+        <translation>Экспорт в CHIRP…</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="321"/>
+        <source>Exports all FM channels to CHIRP CSV.</source>
+        <translation>Экспортирует все FM-каналы в CSV для CHIRP.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="326"/>
+        <source>Import ...</source>
+        <translation>Импорт…</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="329"/>
+        <source>Imports and merges a codeplug into the current one.</source>
+        <translation>Импортирует и объединяет кодплаг с текущим.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="334"/>
+        <source>Refresh Orbital Elements</source>
+        <translation>Обновить орбитальные элементы</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="337"/>
+        <source>Refreshes the orbital elements.</source>
+        <translation>Обновляет орбитальные элементы.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="345"/>
+        <source>Edit Satellites ...</source>
+        <translation>Редактировать спутники…</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="348"/>
+        <source>Opens an editor to edit your satellite database.</source>
+        <translation>Открывает редактор базы спутников.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="356"/>
+        <source>Write satellites</source>
+        <translation>Записать спутники</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="359"/>
+        <source>Writes the orbital elements and transponder information onto the connected device.</source>
+        <translation>Записывает орбитальные элементы и данные транспондера на подключённое устройство.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="70"/>
+        <source>Cannot update callsign DB: %1</source>
+        <translation>Не удалось обновить базу позывных: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="73"/>
+        <source>Callsign database updated &amp; loaded.</source>
+        <translation>База позывных обновлена и загружена.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="78"/>
+        <source>Cannot update talkgroup DB: %1</source>
+        <translation>Не удалось обновить БД токгрупп: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="81"/>
+        <source>Talkgroup database updated &amp; loaded.</source>
+        <translation>База токгрупп обновлена и загружена.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="86"/>
+        <source>Cannot update orbital elements: %1</source>
+        <translation>Не удалось обновить орбитальные элементы: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="89"/>
+        <source>Orbital elements updated &amp; loaded.</source>
+        <translation>Орбитальные элементы обновлены и загружены.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="111"/>
+        <source>Radio IDs</source>
+        <translation>DMR ID</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="113"/>
+        <source>Contacts</source>
+        <translation>Контакты</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="115"/>
+        <source>Group Lists</source>
+        <translation>Групповые списки</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="117"/>
+        <source>Channels</source>
+        <translation>Каналы</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="119"/>
+        <source>Zones</source>
+        <translation>Зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="121"/>
+        <source>Scan Lists</source>
+        <translation>Списки сканирования</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="123"/>
+        <source>GPS/APRS</source>
+        <translation>GPS/APRS</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="125"/>
+        <source>Roaming Channels</source>
+        <translation>Каналы роуминга</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="128"/>
+        <source>Roaming Zones</source>
+        <translation>Зоны роуминга</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="132"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="145"/>
+        <source>Unsaved changes to codeplug.</source>
+        <translation>Несохранённые изменения кодплага.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cc" line="146"/>
+        <source>There are unsaved changes to the current codeplug. These changes are lost if you proceed.</source>
+        <translation>В текущем кодплаге есть несохранённые изменения. Они будут потеряны, если продолжить.</translation>
+    </message>
+</context>
+<context>
+    <name>MultiChannelSelectionDialog</name>
+    <message>
+        <location filename="../src/channelselectiondialog.cc" line="46"/>
+        <source>[Selected]</source>
+        <translation type="unfinished">[Selected]</translation>
+    </message>
+    <message>
+        <location filename="../src/channelselectiondialog.cc" line="69"/>
+        <source>Select a channel:</source>
+        <translation>Выберите канал:</translation>
+    </message>
+</context>
+<context>
+    <name>MultiGroupCallSelectionDialog</name>
+    <message>
+        <location filename="../src/contactselectiondialog.cc" line="18"/>
+        <source>Show private calls</source>
+        <translation type="unfinished">Show private calls</translation>
+    </message>
+    <message>
+        <location filename="../src/contactselectiondialog.cc" line="42"/>
+        <source>Select a group call:</source>
+        <translation type="unfinished">Select a group call:</translation>
+    </message>
+</context>
+<context>
+    <name>MultiRoamingChannelSelectionDialog</name>
+    <message>
+        <location filename="../src/roamingchannelselectiondialog.cc" line="12"/>
+        <source>Select roaming channels</source>
+        <translation type="unfinished">Select roaming channels</translation>
+    </message>
+</context>
+<context>
+    <name>PositioningSystemListView</name>
+    <message>
+        <location filename="../src/positioningsystemlistview.cc" line="73"/>
+        <source>Cannot delete GPS system</source>
+        <translation>Не удалось удалить систему GPS</translation>
+    </message>
+    <message>
+        <location filename="../src/positioningsystemlistview.cc" line="74"/>
+        <source>Cannot delete GPS system: You have to select a GPS system first.</source>
+        <translation>Не удалось удалить систему GPS: сначала выберите систему.</translation>
+    </message>
+    <message>
+        <location filename="../src/positioningsystemlistview.cc" line="83"/>
+        <location filename="../src/positioningsystemlistview.cc" line="87"/>
+        <source>Delete positioning system?</source>
+        <translation>Удалить систему позиционирования?</translation>
+    </message>
+    <message>
+        <location filename="../src/positioningsystemlistview.cc" line="83"/>
+        <source>Delete positioning system %1?</source>
+        <translation>Удалить систему позиционирования «%1»?</translation>
+    </message>
+    <message>
+        <location filename="../src/positioningsystemlistview.cc" line="87"/>
+        <source>Delete %1 positioning systems?</source>
+        <translation>Удалить %1 систем позиционирования?</translation>
+    </message>
+    <message>
+        <location filename="../src/positioningsystemlistview.ui" line="35"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; QDMR is a device independent CPS. However, not all radios support GPS or APRS. Hence these settings might be ignored when programming the code-plug to the device. &lt;/p&gt;&lt;p align="right"&gt;&lt;a href="#hide"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;Hide&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; QDMR is a device independent CPS. However, not all radios support GPS or APRS. Hence these settings might be ignored when programming the code-plug to the device. &lt;/p&gt;&lt;p align="right"&gt;&lt;a href="#hide"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;Hide&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/positioningsystemlistview.ui" line="72"/>
+        <source>Add GPS System</source>
+        <translation>Добавить систему GPS</translation>
+    </message>
+    <message>
+        <location filename="../src/positioningsystemlistview.ui" line="75"/>
+        <source>Alt+G</source>
+        <translation type="unfinished">Alt+G</translation>
+    </message>
+    <message>
+        <location filename="../src/positioningsystemlistview.ui" line="85"/>
+        <source>Add APRS System</source>
+        <translation>Добавить систему APRS</translation>
+    </message>
+    <message>
+        <location filename="../src/positioningsystemlistview.ui" line="88"/>
+        <source>Alt+A</source>
+        <translation type="unfinished">Alt+A</translation>
+    </message>
+    <message>
+        <location filename="../src/positioningsystemlistview.ui" line="95"/>
+        <source>Delete Position System</source>
+        <translation type="unfinished">Delete Position System</translation>
+    </message>
+    <message>
+        <location filename="../src/positioningsystemlistview.ui" line="98"/>
+        <source>Alt+-</source>
+        <translation type="unfinished">Alt+-</translation>
+    </message>
+</context>
+<context>
+    <name>PositioningSystemListWrapper</name>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="789"/>
+        <source>DMR</source>
+        <translation>DMR</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="791"/>
+        <source>APRS</source>
+        <translation>APRS</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="801"/>
+        <location filename="../src/configitemwrapper.cc" line="829"/>
+        <location filename="../src/configitemwrapper.cc" line="837"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="818"/>
+        <location filename="../src/configitemwrapper.cc" line="822"/>
+        <source>[Selected]</source>
+        <translation type="unfinished">[Selected]</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="853"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="854"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="855"/>
+        <source>Destination</source>
+        <translation type="unfinished">Destination</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="856"/>
+        <source>Period</source>
+        <translation type="unfinished">Period</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="857"/>
+        <source>Channel</source>
+        <translation>Канал</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="858"/>
+        <source>Message</source>
+        <translation type="unfinished">Message</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="859"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+</context>
+<context>
+    <name>PropertyDelegate</name>
+    <message>
+        <location filename="../src/propertydelegate.cc" line="74"/>
+        <source>None</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="../src/propertydelegate.cc" line="75"/>
+        <source>Off</source>
+        <translation>Выкл.</translation>
+    </message>
+    <message>
+        <location filename="../src/propertydelegate.cc" line="112"/>
+        <source>False</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="../src/propertydelegate.cc" line="113"/>
+        <source>True</source>
+        <translation>Да</translation>
+    </message>
+    <message>
+        <location filename="../src/propertydelegate.cc" line="142"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+</context>
+<context>
+    <name>PropertyWrapper</name>
+    <message>
+        <location filename="../src/extensionwrapper.cc" line="352"/>
+        <source>new element</source>
+        <translation type="unfinished">new element</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionwrapper.cc" line="528"/>
+        <source>Property</source>
+        <translation type="unfinished">Property</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionwrapper.cc" line="529"/>
+        <source>Value</source>
+        <translation>Значение</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionwrapper.cc" line="530"/>
+        <source>Description</source>
+        <translation>Описание</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionwrapper.cc" line="592"/>
+        <source>true</source>
+        <translation type="unfinished">true</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionwrapper.cc" line="593"/>
+        <source>false</source>
+        <translation type="unfinished">false</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionwrapper.cc" line="614"/>
+        <source>None</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionwrapper.cc" line="616"/>
+        <source>Off</source>
+        <translation>Выкл.</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionwrapper.cc" line="627"/>
+        <location filename="../src/extensionwrapper.cc" line="635"/>
+        <location filename="../src/extensionwrapper.cc" line="643"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionwrapper.cc" line="645"/>
+        <source>Instance of %1</source>
+        <translation type="unfinished">Instance of %1</translation>
+    </message>
+    <message>
+        <location filename="../src/extensionwrapper.cc" line="650"/>
+        <source>List of %1 instances</source>
+        <translation type="unfinished">List of %1 instances</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/rxgrouplistdialog.cc" line="126"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+</context>
+<context>
+    <name>RXGroupListDialog</name>
+    <message>
+        <location filename="../src/rxgrouplistdialog.cc" line="17"/>
+        <source>Create Group List</source>
+        <translation>Создать групповой список</translation>
+    </message>
+    <message>
+        <location filename="../src/rxgrouplistdialog.cc" line="24"/>
+        <source>Edit Group List</source>
+        <translation>Изменить групповой список</translation>
+    </message>
+    <message>
+        <location filename="../src/rxgrouplistdialog.cc" line="82"/>
+        <source>Cannot remove group call</source>
+        <translation type="unfinished">Cannot remove group call</translation>
+    </message>
+    <message>
+        <location filename="../src/rxgrouplistdialog.cc" line="83"/>
+        <source>Cannot remove group call: You have to select at least one group call first.</source>
+        <translation type="unfinished">Cannot remove group call: You have to select at least one group call first.</translation>
+    </message>
+    <message>
+        <location filename="../src/rxgrouplistdialog.ui" line="30"/>
+        <source>Basic</source>
+        <translation>Основное</translation>
+    </message>
+    <message>
+        <location filename="../src/rxgrouplistdialog.ui" line="38"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/rxgrouplistdialog.ui" line="65"/>
+        <source>Add Contact</source>
+        <translation>Добавить контакт</translation>
+    </message>
+    <message>
+        <location filename="../src/rxgrouplistdialog.ui" line="68"/>
+        <source>Alt++</source>
+        <translation type="unfinished">Alt++</translation>
+    </message>
+    <message>
+        <location filename="../src/rxgrouplistdialog.ui" line="75"/>
+        <source>Remove Contact</source>
+        <translation type="unfinished">Remove Contact</translation>
+    </message>
+    <message>
+        <location filename="../src/rxgrouplistdialog.ui" line="78"/>
+        <source>Alt+-</source>
+        <translation type="unfinished">Alt+-</translation>
+    </message>
+    <message>
+        <location filename="../src/rxgrouplistdialog.ui" line="88"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+</context>
+<context>
+    <name>RadioIDListView</name>
+    <message>
+        <location filename="../src/radioidlistview.cc" line="61"/>
+        <source>Cannot delete radio IDs</source>
+        <translation>Не удалось удалить DMR ID</translation>
+    </message>
+    <message>
+        <location filename="../src/radioidlistview.cc" line="62"/>
+        <source>Cannot delete radio IDs: You have to select a radio ID first.</source>
+        <translation>Не удалось удалить DMR ID: сначала выберите запись.</translation>
+    </message>
+    <message>
+        <location filename="../src/radioidlistview.cc" line="71"/>
+        <source>Delete radio ID?</source>
+        <translation>Удалить DMR ID?</translation>
+    </message>
+    <message>
+        <location filename="../src/radioidlistview.cc" line="71"/>
+        <source>Delete radio ID %1?</source>
+        <translation>Удалить DMR ID «%1»?</translation>
+    </message>
+    <message>
+        <location filename="../src/radioidlistview.cc" line="75"/>
+        <source>Delete scan lists?</source>
+        <translation>Удалить выбранные DMR ID?</translation>
+    </message>
+    <message>
+        <location filename="../src/radioidlistview.cc" line="75"/>
+        <source>Delete %1 scan lists?</source>
+        <translation>Удалить %1 записей DMR ID?</translation>
+    </message>
+    <message>
+        <location filename="../src/radioidlistview.ui" line="22"/>
+        <source>Default Radio ID</source>
+        <translation>Основной DMR ID</translation>
+    </message>
+    <message>
+        <location filename="../src/radioidlistview.ui" line="46"/>
+        <source>Add Radio ID</source>
+        <translation>Добавить DMR ID</translation>
+    </message>
+    <message>
+        <location filename="../src/radioidlistview.ui" line="53"/>
+        <source>Delete Radio ID</source>
+        <translation>Удалить DMR ID</translation>
+    </message>
+</context>
+<context>
+    <name>RadioIdListWrapper</name>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="998"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="1013"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="1014"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="1015"/>
+        <source>Number</source>
+        <translation type="unfinished">Number</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="1016"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+</context>
+<context>
+    <name>RadioSelectionDialog</name>
+    <message>
+        <location filename="../src/radioselectiondialog.ui" line="14"/>
+        <source>Cannot auto-detect radio</source>
+        <translation type="unfinished">Cannot auto-detect radio</translation>
+    </message>
+    <message>
+        <location filename="../src/radioselectiondialog.ui" line="20"/>
+        <source>Select a specific radio</source>
+        <translation type="unfinished">Select a specific radio</translation>
+    </message>
+</context>
+<context>
+    <name>ReleaseNotes</name>
+    <message>
+        <location filename="../src/releasenotes.cc" line="31"/>
+        <source>Cannot download release notes from https://github.com/hmatuschek/qdmr
+	 %1</source>
+        <translation type="unfinished">Cannot download release notes from https://github.com/hmatuschek/qdmr
+	 %1</translation>
+    </message>
+    <message>
+        <location filename="../src/releasenotes.cc" line="43"/>
+        <source>Cannot read release notes from https://github.com/hmatuschek/qdmr
+	Release is not a JSON object!</source>
+        <translation type="unfinished">Cannot read release notes from https://github.com/hmatuschek/qdmr
+	Release is not a JSON object!</translation>
+    </message>
+    <message>
+        <location filename="../src/releasenotes.cc" line="48"/>
+        <source>Cannot read release notes from https://github.com/hmatuschek/qdmr
+	Release does not contain a release note.</source>
+        <translation type="unfinished">Cannot read release notes from https://github.com/hmatuschek/qdmr
+	Release does not contain a release note.</translation>
+    </message>
+    <message>
+        <location filename="../src/releasenotes.cc" line="59"/>
+        <source>qDMR was updated to version %1</source>
+        <translation type="unfinished">qDMR was updated to version %1</translation>
+    </message>
+</context>
+<context>
+    <name>RoamingChannelDialog</name>
+    <message>
+        <location filename="../src/roamingchanneldialog.ui" line="28"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchanneldialog.ui" line="35"/>
+        <source>RX Frequency [MHz]</source>
+        <translation type="unfinished">RX Frequency [MHz]</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchanneldialog.ui" line="42"/>
+        <source>TX Frequency [MHz]</source>
+        <translation type="unfinished">TX Frequency [MHz]</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchanneldialog.ui" line="49"/>
+        <source>Time Slot</source>
+        <translation type="unfinished">Time Slot</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchanneldialog.ui" line="56"/>
+        <source>Color Code</source>
+        <translation type="unfinished">Color Code</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchanneldialog.ui" line="74"/>
+        <location filename="../src/roamingchanneldialog.ui" line="95"/>
+        <source>Selected</source>
+        <translation type="unfinished">Selected</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchanneldialog.cc" line="37"/>
+        <source>Edit roaming channel</source>
+        <translation type="unfinished">Edit roaming channel</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchanneldialog.cc" line="39"/>
+        <source>Create roaming channel</source>
+        <translation>Создать канал роуминга</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchanneldialog.cc" line="46"/>
+        <source>TS 1</source>
+        <translation type="unfinished">TS 1</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchanneldialog.cc" line="47"/>
+        <source>TS 2</source>
+        <translation type="unfinished">TS 2</translation>
+    </message>
+</context>
+<context>
+    <name>RoamingChannelListView</name>
+    <message>
+        <location filename="../src/roamingchannellistview.ui" line="26"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; QDMR is a device independent CPS. However, not all radios support Roaming. Hence these settings might be ignored when programming the code-plug to the device. &lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Hint:&lt;/span&gt; You do not need to add roaming channel explicitly, just create roaming zones and add channels there. These channels are then added to this list.&lt;/p&gt;&lt;p align="right"&gt;&lt;a href="#hide"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;Hide&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; QDMR is a device independent CPS. However, not all radios support Roaming. Hence these settings might be ignored when programming the code-plug to the device. &lt;/p&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Hint:&lt;/span&gt; You do not need to add roaming channel explicitly, just create roaming zones and add channels there. These channels are then added to this list.&lt;/p&gt;&lt;p align="right"&gt;&lt;a href="#hide"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;Hide&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchannellistview.ui" line="51"/>
+        <source>Add Roaming Channel</source>
+        <translation>Добавить канал роуминга</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchannellistview.ui" line="58"/>
+        <source>Delete Roaming Channel</source>
+        <translation>Удалить канал роуминга</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchannellistview.cc" line="63"/>
+        <source>Cannot delete roaming channel</source>
+        <translation>Не удалось удалить канал роуминга</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchannellistview.cc" line="64"/>
+        <source>Cannot delete roaming channel: You have to select a channel first.</source>
+        <translation>Не удалось удалить канал роуминга: сначала выберите канал.</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchannellistview.cc" line="74"/>
+        <location filename="../src/roamingchannellistview.cc" line="78"/>
+        <source>Delete roaming channel?</source>
+        <translation>Удалить канал роуминга?</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchannellistview.cc" line="74"/>
+        <source>Delete roaming channel %1?</source>
+        <translation>Удалить канал роуминга «%1»?</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingchannellistview.cc" line="78"/>
+        <source>Delete %1 roaming channel?</source>
+        <translation>Удалить %1 канал(ов) роуминга?</translation>
+    </message>
+</context>
+<context>
+    <name>RoamingChannelListWrapper</name>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="557"/>
+        <location filename="../src/configitemwrapper.cc" line="565"/>
+        <source>[Selected]</source>
+        <translation type="unfinished">[Selected]</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="579"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="594"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="595"/>
+        <source>RX Frequency</source>
+        <translation>Частота приёма</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="596"/>
+        <source>TX Frequency</source>
+        <translation>Частота передачи</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="598"/>
+        <source>TS</source>
+        <translation>TS</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="599"/>
+        <source>Zones</source>
+        <translation>Зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="600"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="597"/>
+        <source>CC</source>
+        <translation>CC</translation>
+    </message>
+</context>
+<context>
+    <name>RoamingChannelRefListWrapper</name>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="627"/>
+        <source>Roaming Channel</source>
+        <translation type="unfinished">Roaming Channel</translation>
+    </message>
+</context>
+<context>
+    <name>RoamingListWrapper</name>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="953"/>
+        <source>%1 (containing %2 channels)</source>
+        <translation type="unfinished">%1 (containing %2 channels)</translation>
+    </message>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="960"/>
+        <source>Roaming zone</source>
+        <translation type="unfinished">Roaming zone</translation>
+    </message>
+</context>
+<context>
+    <name>RoamingZoneDialog</name>
+    <message>
+        <location filename="../src/roamingzonedialog.cc" line="15"/>
+        <source>Create Roaming Zone</source>
+        <translation>Создать зону роуминга</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonedialog.cc" line="22"/>
+        <source>Set Roaming Zone</source>
+        <translation type="unfinished">Set Roaming Zone</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonedialog.cc" line="83"/>
+        <source>Cannot remove channels.</source>
+        <translation type="unfinished">Cannot remove channels.</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonedialog.cc" line="84"/>
+        <source>Cannot remove channels. Select at least one channel first.</source>
+        <translation type="unfinished">Cannot remove channels. Select at least one channel first.</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonedialog.ui" line="30"/>
+        <source>Basic</source>
+        <translation>Основное</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonedialog.ui" line="38"/>
+        <source>Name:</source>
+        <translation type="unfinished">Name:</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonedialog.ui" line="62"/>
+        <source>Add Roaming Channel</source>
+        <translation>Добавить канал роуминга</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonedialog.ui" line="69"/>
+        <source>Add DMR Channel</source>
+        <translation>Добавить DMR-канал</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonedialog.ui" line="72"/>
+        <source>Alt++</source>
+        <translation type="unfinished">Alt++</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonedialog.ui" line="79"/>
+        <source>Remove Channel</source>
+        <translation type="unfinished">Remove Channel</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonedialog.ui" line="82"/>
+        <source>Alt+-</source>
+        <translation type="unfinished">Alt+-</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonedialog.ui" line="92"/>
+        <source>Extension</source>
+        <translation type="unfinished">Extension</translation>
+    </message>
+</context>
+<context>
+    <name>RoamingZoneListView</name>
+    <message>
+        <location filename="../src/roamingzonelistview.cc" line="52"/>
+        <source>Generate roaming zone</source>
+        <translation type="unfinished">Generate roaming zone</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.cc" line="53"/>
+        <source>Create a roaming zone by collecting all channels with these group calls.</source>
+        <translation type="unfinished">Create a roaming zone by collecting all channels with these group calls.</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.cc" line="87"/>
+        <source>Cannot delete roaming zone</source>
+        <translation>Не удалось удалить зону роуминга</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.cc" line="88"/>
+        <source>Cannot delete roaming zone: You have to select a zone first.</source>
+        <translation>Не удалось удалить зону роуминга: сначала выберите зону.</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.cc" line="98"/>
+        <source>Delete roaming zone?</source>
+        <translation>Удалить зону роуминга?</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.cc" line="98"/>
+        <source>Delete roaming zone %1?</source>
+        <translation>Удалить зону роуминга «%1»?</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.cc" line="102"/>
+        <source>Delete roaming zones?</source>
+        <translation>Удалить зоны роуминга?</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.cc" line="102"/>
+        <source>Delete %1 roaming zones?</source>
+        <translation type="unfinished">Delete %1 roaming zones?</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.ui" line="23"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; QDMR is a device independent CPS. However, not all radios support Roaming. Hence these settings might be ignored when programming the code-plug to the device. &lt;/p&gt;&lt;p align="right"&gt;&lt;a href="#hide"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;Hide&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; QDMR is a device independent CPS. However, not all radios support Roaming. Hence these settings might be ignored when programming the code-plug to the device. &lt;/p&gt;&lt;p align="right"&gt;&lt;a href="#hide"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;Hide&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.ui" line="48"/>
+        <source>Add Roaming Zone</source>
+        <translation>Добавить зону роуминга</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.ui" line="51"/>
+        <source>Alt++</source>
+        <translation type="unfinished">Alt++</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.ui" line="58"/>
+        <source>Generate Roaming Zone</source>
+        <translation type="unfinished">Generate Roaming Zone</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.ui" line="65"/>
+        <source>Delete Roaming Zone</source>
+        <translation>Удалить зону роуминга</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonelistview.ui" line="68"/>
+        <source>Alt+-</source>
+        <translation type="unfinished">Alt+-</translation>
+    </message>
+</context>
+<context>
+    <name>RoamingZoneSelect</name>
+    <message>
+        <location filename="../src/roamingzonedialog.cc" line="121"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+    <message>
+        <location filename="../src/roamingzonedialog.cc" line="122"/>
+        <source>[Default]</source>
+        <translation type="unfinished">[Default]</translation>
+    </message>
+</context>
+<context>
+    <name>SatelliteDatabaseDialog</name>
+    <message>
+        <location filename="../src/satellitedatabasedialog.ui" line="20"/>
+        <source>Edit satellite database</source>
+        <translation type="unfinished">Edit satellite database</translation>
+    </message>
+    <message>
+        <location filename="../src/satellitedatabasedialog.ui" line="48"/>
+        <source>Add</source>
+        <translation>Добавить</translation>
+    </message>
+    <message>
+        <location filename="../src/satellitedatabasedialog.ui" line="55"/>
+        <source>Delete</source>
+        <translation>Удалить</translation>
+    </message>
+</context>
+<context>
+    <name>SatelliteSelectionDialog</name>
+    <message>
+        <location filename="../src/satelliteselectiondialog.ui" line="20"/>
+        <location filename="../src/satelliteselectiondialog.ui" line="26"/>
+        <source>Select a satellite</source>
+        <translation type="unfinished">Select a satellite</translation>
+    </message>
+</context>
+<context>
+    <name>SatelliteTransponderDialog</name>
+    <message>
+        <location filename="../src/satellitetransponderdialog.ui" line="14"/>
+        <source>Edit Satellite Transponder</source>
+        <translation type="unfinished">Edit Satellite Transponder</translation>
+    </message>
+    <message>
+        <location filename="../src/satellitetransponderdialog.ui" line="26"/>
+        <source>FM Voice Transponder</source>
+        <translation type="unfinished">FM Voice Transponder</translation>
+    </message>
+    <message>
+        <location filename="../src/satellitetransponderdialog.ui" line="32"/>
+        <location filename="../src/satellitetransponderdialog.ui" line="105"/>
+        <source>Uplink Frequency</source>
+        <translation type="unfinished">Uplink Frequency</translation>
+    </message>
+    <message>
+        <location filename="../src/satellitetransponderdialog.ui" line="42"/>
+        <location filename="../src/satellitetransponderdialog.ui" line="121"/>
+        <source>Uplink Tone</source>
+        <translation type="unfinished">Uplink Tone</translation>
+    </message>
+    <message>
+        <location filename="../src/satellitetransponderdialog.ui" line="58"/>
+        <location filename="../src/satellitetransponderdialog.ui" line="143"/>
+        <source>Downlink Frequency</source>
+        <translation type="unfinished">Downlink Frequency</translation>
+    </message>
+    <message>
+        <location filename="../src/satellitetransponderdialog.ui" line="68"/>
+        <location filename="../src/satellitetransponderdialog.ui" line="159"/>
+        <source>Downlink Tone</source>
+        <translation type="unfinished">Downlink Tone</translation>
+    </message>
+    <message>
+        <location filename="../src/satellitetransponderdialog.ui" line="93"/>
+        <source>APRS Transponder</source>
+        <translation type="unfinished">APRS Transponder</translation>
+    </message>
+    <message>
+        <location filename="../src/satellitetransponderdialog.ui" line="184"/>
+        <source>Beacon</source>
+        <translation type="unfinished">Beacon</translation>
+    </message>
+    <message>
+        <location filename="../src/satellitetransponderdialog.ui" line="196"/>
+        <source>Beacon Frequency</source>
+        <translation type="unfinished">Beacon Frequency</translation>
+    </message>
+</context>
+<context>
+    <name>ScanListDialog</name>
+    <message>
+        <location filename="../src/scanlistdialog.ui" line="20"/>
+        <location filename="../src/scanlistdialog.cc" line="13"/>
+        <source>Edit Scan List</source>
+        <translation>Изменить список сканирования</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.ui" line="30"/>
+        <source>Basic</source>
+        <translation>Основное</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.ui" line="38"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.ui" line="48"/>
+        <source>Primary Channel (50%)</source>
+        <translation type="unfinished">Primary Channel (50%)</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.ui" line="65"/>
+        <source>Secondary Channel (25%)</source>
+        <translation type="unfinished">Secondary Channel (25%)</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.ui" line="82"/>
+        <source>Transmit Channel</source>
+        <translation type="unfinished">Transmit Channel</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.ui" line="113"/>
+        <source>Add Channel</source>
+        <translation>Добавить канал</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.ui" line="116"/>
+        <source>Alt++</source>
+        <translation type="unfinished">Alt++</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.ui" line="123"/>
+        <source>Remove Channel</source>
+        <translation type="unfinished">Remove Channel</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.ui" line="126"/>
+        <source>Alt+-</source>
+        <translation type="unfinished">Alt+-</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.ui" line="136"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.cc" line="24"/>
+        <source>Create Scan List</source>
+        <translation>Создать список сканирования</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.cc" line="34"/>
+        <location filename="../src/scanlistdialog.cc" line="36"/>
+        <source>[None]</source>
+        <translation type="unfinished">[None]</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.cc" line="35"/>
+        <location filename="../src/scanlistdialog.cc" line="37"/>
+        <location filename="../src/scanlistdialog.cc" line="39"/>
+        <source>[Selected]</source>
+        <translation type="unfinished">[Selected]</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistdialog.cc" line="38"/>
+        <source>[Last]</source>
+        <translation type="unfinished">[Last]</translation>
+    </message>
+</context>
+<context>
+    <name>ScanListsView</name>
+    <message>
+        <location filename="../src/scanlistsview.cc" line="42"/>
+        <source>Cannot delete scanlist</source>
+        <translation>Не удалось удалить список сканирования</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistsview.cc" line="43"/>
+        <source>Cannot delete scanlist: You have to select a scanlist first.</source>
+        <translation>Не удалось удалить список сканирования: сначала выберите список.</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistsview.cc" line="53"/>
+        <source>Delete scan list?</source>
+        <translation>Удалить список сканирования?</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistsview.cc" line="53"/>
+        <source>Delete scan list %1?</source>
+        <translation>Удалить список сканирования «%1»?</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistsview.cc" line="57"/>
+        <source>Delete scan lists?</source>
+        <translation>Удалить списки сканирования?</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistsview.cc" line="57"/>
+        <source>Delete %1 scan lists?</source>
+        <translation>Удалить %1 списков сканирования?</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistsview.ui" line="35"/>
+        <source>Add Scan List</source>
+        <translation>Добавить список сканирования</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistsview.ui" line="38"/>
+        <source>Alt++</source>
+        <translation type="unfinished">Alt++</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistsview.ui" line="45"/>
+        <source>Delete Scan List</source>
+        <translation>Удалить список сканирования</translation>
+    </message>
+    <message>
+        <location filename="../src/scanlistsview.ui" line="48"/>
+        <source>Alt+-</source>
+        <translation type="unfinished">Alt+-</translation>
+    </message>
+</context>
+<context>
+    <name>ScanListsWrapper</name>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="887"/>
+        <source>Scan-List</source>
+        <translation type="unfinished">Scan-List</translation>
+    </message>
+</context>
+<context>
+    <name>SearchPopup</name>
+    <message>
+        <location filename="../src/searchpopup.cc" line="18"/>
+        <source>Ctrl+F</source>
+        <translation type="unfinished">Ctrl+F</translation>
+    </message>
+    <message>
+        <location filename="../src/searchpopup.cc" line="92"/>
+        <location filename="../src/searchpopup.cc" line="107"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+</context>
+<context>
+    <name>SelectiveCallBox</name>
+    <message>
+        <location filename="../src/selectivecallbox.cc" line="16"/>
+        <source>None</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="../src/selectivecallbox.cc" line="17"/>
+        <source>CTCSS</source>
+        <translation>CTCSS</translation>
+    </message>
+    <message>
+        <location filename="../src/selectivecallbox.cc" line="18"/>
+        <source>DCS</source>
+        <translation>DCS</translation>
+    </message>
+    <message>
+        <location filename="../src/selectivecallbox.cc" line="40"/>
+        <source>Hz</source>
+        <translation type="unfinished">Hz</translation>
+    </message>
+    <message>
+        <location filename="../src/selectivecallbox.cc" line="50"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Inverted</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../src/settings.cc" line="461"/>
+        <source>Warning!</source>
+        <translation>Внимание!</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="20"/>
+        <source>Settings</source>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="42"/>
+        <source>Location</source>
+        <translation>Местоположение</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="48"/>
+        <source>System location</source>
+        <translation>Системное местоположение</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="62"/>
+        <source>Locator</source>
+        <translation>Локатор</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="81"/>
+        <source>Repeater Info Sources</source>
+        <translation>Источники данных о ретрансляторах</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="96"/>
+        <location filename="../src/settingsdialog.ui" line="132"/>
+        <location filename="../src/settingsdialog.ui" line="146"/>
+        <location filename="../src/settingsdialog.ui" line="160"/>
+        <source>enable</source>
+        <translation>включить</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="212"/>
+        <source>Radio Programming</source>
+        <translation>Программирование радиостанции</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="221"/>
+        <source>Update codeplug</source>
+        <translation>Обновлять кодплаг</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="228"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Update the codeplug on the radio. If not selected, the codeplug on the radio gets overridden with possibly incomplete default values.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If selected, QDMR downloads the codeplug from the radio and updates only those settings specified. The remaining settings within the radio are not touched (recommended).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Update the codeplug on the radio. If not selected, the codeplug on the radio gets overridden with possibly incomplete default values.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If selected, QDMR downloads the codeplug from the radio and updates only those settings specified. The remaining settings within the radio are not touched (recommended).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="238"/>
+        <source>Auto-enable GPS</source>
+        <translation>Включать GPS автоматически</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="245"/>
+        <source>When a GPS or APRS system is defined and used for any channel, the GPS module gets enabled automatically.</source>
+        <translation type="unfinished">When a GPS or APRS system is defined and used for any channel, the GPS module gets enabled automatically.</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="262"/>
+        <source>When a roaming zone is defined and used by any channel, the automatic roaming gets enabled.</source>
+        <translation type="unfinished">When a roaming zone is defined and used by any channel, the automatic roaming gets enabled.</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="255"/>
+        <source>Auto-enable roaming</source>
+        <translation>Включать роуминг автоматически</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="30"/>
+        <source>Data Sources</source>
+        <translation>Источники данных</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="110"/>
+        <source>World</source>
+        <translation>Мир</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="115"/>
+        <source>North America</source>
+        <translation>Северная Америка</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="171"/>
+        <source>Programming</source>
+        <translation>Программирование</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="183"/>
+        <source>Radio Interfaces</source>
+        <translation>Интерфейсы радиостанции</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="189"/>
+        <source>disable auto-detect</source>
+        <translation>отключить автоопределение</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="272"/>
+        <source>Ignore verification warnings</source>
+        <translation>Игнорировать предупреждения проверки</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="279"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;As the communication interface to the radio is kept open after verification, time-outs may occur and the code-plug upload may fail when the verification dialog pops up. To prevent this, verification warnings can be ignored, eliminating the time-gap between verification and upload. Verification errors still prevent the upload.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;As the communication interface to the radio is kept open after verification, time-outs may occur and the code-plug upload may fail when the verification dialog pops up. To prevent this, verification warnings can be ignored, eliminating the time-gap between verification and upload. Verification errors still prevent the upload.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="289"/>
+        <source>Ignore frequency limits</source>
+        <translation>Игнорировать ограничения по частоте</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="296"/>
+        <source>Do not set this option unless you know what you are doing.</source>
+        <translation type="unfinished">Do not set this option unless you know what you are doing.</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="306"/>
+        <source>Update Device Clock</source>
+        <translation>Обновлять часы устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="329"/>
+        <source>Call-Sign DB</source>
+        <translation>База позывных</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="335"/>
+        <source>Limit number of DB entries</source>
+        <translation type="unfinished">Limit number of DB entries</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="342"/>
+        <source>When enabled, the number of DB entries will be limited. Otherwise the maximum number of entries are generated (device dependent).</source>
+        <translation type="unfinished">When enabled, the number of DB entries will be limited. Otherwise the maximum number of entries are generated (device dependent).</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="352"/>
+        <source>Number of DB entries</source>
+        <translation type="unfinished">Number of DB entries</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="365"/>
+        <source>Specifies the number of DB entries (if enabled above).</source>
+        <translation type="unfinished">Specifies the number of DB entries (if enabled above).</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="378"/>
+        <source>Select using my DMR ID</source>
+        <translation type="unfinished">Select using my DMR ID</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="385"/>
+        <source>If enabled, the entries are selected using the users DMR ID.</source>
+        <translation type="unfinished">If enabled, the entries are selected using the users DMR ID.</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="395"/>
+        <source>Select using prefixes</source>
+        <translation type="unfinished">Select using prefixes</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="402"/>
+        <source>If enabled, these comma separated DMR ID prefixes are used to select the call-sign DB entries.</source>
+        <translation type="unfinished">If enabled, these comma separated DMR ID prefixes are used to select the call-sign DB entries.</translation>
+    </message>
+</context>
+<context>
+    <name>SquelchEdit</name>
+    <message>
+        <location filename="../src/squelchedit.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">Form</translation>
+    </message>
+    <message>
+        <location filename="../src/squelchedit.ui" line="32"/>
+        <source>Open</source>
+        <translation>Открыть</translation>
+    </message>
+    <message>
+        <location filename="../src/squelchedit.ui" line="45"/>
+        <source>Uses the global squelch setting if enabled.</source>
+        <translation type="unfinished">Uses the global squelch setting if enabled.</translation>
+    </message>
+    <message>
+        <location filename="../src/squelchedit.ui" line="48"/>
+        <source>Default</source>
+        <translation>По умолчанию</translation>
+    </message>
+</context>
+<context>
+    <name>TimeslotSelect</name>
+    <message>
+        <location filename="../src/timeslotselect.cc" line="6"/>
+        <source>Slot 1</source>
+        <translation>Слот 1</translation>
+    </message>
+    <message>
+        <location filename="../src/timeslotselect.cc" line="7"/>
+        <source>Slot 2</source>
+        <translation>Слот 2</translation>
+    </message>
+</context>
+<context>
+    <name>TransponderFrequencyEditor</name>
+    <message>
+        <location filename="../src/transponderfrequencydelegate.cc" line="28"/>
+        <source>None</source>
+        <translation>Нет</translation>
+    </message>
+</context>
+<context>
+    <name>VerifyDialog</name>
+    <message>
+        <location filename="../src/verifydialog.ui" line="14"/>
+        <source>Verify Codeplug</source>
+        <translation>Проверить кодплаг</translation>
+    </message>
+    <message>
+        <location filename="../src/verifydialog.ui" line="20"/>
+        <source>The codeplug cannot be uploaded, unless all critical issues (red) are resolved.</source>
+        <translation>Запись кодплага невозможна, пока не устранены все критические проблемы (красные).</translation>
+    </message>
+</context>
+<context>
+    <name>ZoneDialog</name>
+    <message>
+        <location filename="../src/zonedialog.ui" line="20"/>
+        <location filename="../src/zonedialog.cc" line="18"/>
+        <source>Edit Zone</source>
+        <translation>Изменить зону</translation>
+    </message>
+    <message>
+        <location filename="../src/zonedialog.ui" line="30"/>
+        <source>Basic</source>
+        <translation>Основное</translation>
+    </message>
+    <message>
+        <location filename="../src/zonedialog.ui" line="39"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align="justify"&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; Zones are collections of channels that are usually valid for a specific region. I.e., a collection of channels for repeaters within a certain region. &lt;/p&gt;&lt;p align="justify"&gt;QDMR manages zones by allowing for two independent channel lists for each VFO of the radio (if it has two). Many radios however, allow one to assign zones to each VFO individually. In these cases, QDMR will split the zone into two (A &amp;amp; B) and program them individually into the radio.&lt;/p&gt;&lt;p align="right"&gt;&lt;a href="#hide"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;Hide&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align="justify"&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; Zones are collections of channels that are usually valid for a specific region. I.e., a collection of channels for repeaters within a certain region. &lt;/p&gt;&lt;p align="justify"&gt;QDMR manages zones by allowing for two independent channel lists for each VFO of the radio (if it has two). Many radios however, allow one to assign zones to each VFO individually. In these cases, QDMR will split the zone into two (A &amp;amp; B) and program them individually into the radio.&lt;/p&gt;&lt;p align="right"&gt;&lt;a href="#hide"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;Hide&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/zonedialog.ui" line="54"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/zonedialog.ui" line="77"/>
+        <source>Channels A</source>
+        <translation>Каналы A</translation>
+    </message>
+    <message>
+        <location filename="../src/zonedialog.ui" line="95"/>
+        <location filename="../src/zonedialog.ui" line="138"/>
+        <source>add</source>
+        <translation type="unfinished">add</translation>
+    </message>
+    <message>
+        <location filename="../src/zonedialog.ui" line="102"/>
+        <location filename="../src/zonedialog.ui" line="145"/>
+        <source>remove</source>
+        <translation type="unfinished">remove</translation>
+    </message>
+    <message>
+        <location filename="../src/zonedialog.ui" line="120"/>
+        <source>Channels B</source>
+        <translation>Каналы B</translation>
+    </message>
+    <message>
+        <location filename="../src/zonedialog.ui" line="160"/>
+        <source>Extension</source>
+        <translation type="unfinished">Extension</translation>
+    </message>
+    <message>
+        <location filename="../src/zonedialog.cc" line="28"/>
+        <source>Create Zone</source>
+        <translation>Создать зону</translation>
+    </message>
+    <message>
+        <location filename="../src/zonedialog.cc" line="73"/>
+        <location filename="../src/zonedialog.cc" line="104"/>
+        <source>Cannot remove channel</source>
+        <translation type="unfinished">Cannot remove channel</translation>
+    </message>
+    <message>
+        <location filename="../src/zonedialog.cc" line="74"/>
+        <location filename="../src/zonedialog.cc" line="105"/>
+        <source>Select at least one channel first.</source>
+        <translation type="unfinished">Select at least one channel first.</translation>
+    </message>
+</context>
+<context>
+    <name>ZoneListView</name>
+    <message>
+        <location filename="../src/zonelistview.cc" line="41"/>
+        <source>Cannot delete zone</source>
+        <translation>Не удалось удалить зону</translation>
+    </message>
+    <message>
+        <location filename="../src/zonelistview.cc" line="42"/>
+        <source>Cannot delete zone: You have to select a zone first.</source>
+        <translation>Не удалось удалить зону: сначала выберите зону.</translation>
+    </message>
+    <message>
+        <location filename="../src/zonelistview.cc" line="52"/>
+        <source>Delete zone?</source>
+        <translation>Удалить зону?</translation>
+    </message>
+    <message>
+        <location filename="../src/zonelistview.cc" line="52"/>
+        <source>Delete zone %1?</source>
+        <translation>Удалить зону «%1»?</translation>
+    </message>
+    <message>
+        <location filename="../src/zonelistview.cc" line="56"/>
+        <source>Delete zones?</source>
+        <translation type="unfinished">Delete zones?</translation>
+    </message>
+    <message>
+        <location filename="../src/zonelistview.cc" line="56"/>
+        <source>Delete %1 zones?</source>
+        <translation>Удалить %1 зон?</translation>
+    </message>
+    <message>
+        <location filename="../src/zonelistview.ui" line="32"/>
+        <source>Add Zone</source>
+        <translation>Добавить зону</translation>
+    </message>
+    <message>
+        <location filename="../src/zonelistview.ui" line="35"/>
+        <source>Alt++</source>
+        <translation type="unfinished">Alt++</translation>
+    </message>
+    <message>
+        <location filename="../src/zonelistview.ui" line="42"/>
+        <source>Delete Zone</source>
+        <translation>Удалить зону</translation>
+    </message>
+    <message>
+        <location filename="../src/zonelistview.ui" line="45"/>
+        <source>Alt+-</source>
+        <translation type="unfinished">Alt+-</translation>
+    </message>
+</context>
+<context>
+    <name>ZoneListWrapper</name>
+    <message>
+        <location filename="../src/configitemwrapper.cc" line="758"/>
+        <source>Zone</source>
+        <translation>Зона</translation>
+    </message>
+</context>
+<context>
+    <name>aprssystemdialog</name>
+    <message>
+        <location filename="../src/aprssystemdialog.ui" line="20"/>
+        <source>Edit APRS System</source>
+        <translation>Изменить систему APRS</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.ui" line="30"/>
+        <source>Basic</source>
+        <translation>Основное</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.ui" line="42"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.ui" line="52"/>
+        <source>Channel</source>
+        <translation>Канал</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.ui" line="62"/>
+        <source>Source</source>
+        <translation type="unfinished">Source</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.ui" line="100"/>
+        <source>Destination</source>
+        <translation type="unfinished">Destination</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.ui" line="138"/>
+        <source>Path</source>
+        <translation type="unfinished">Path</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.ui" line="145"/>
+        <source>Icon</source>
+        <translation type="unfinished">Icon</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.ui" line="152"/>
+        <source>Update period [s]</source>
+        <translation type="unfinished">Update period [s]</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.ui" line="159"/>
+        <source>Message</source>
+        <translation type="unfinished">Message</translation>
+    </message>
+    <message>
+        <location filename="../src/aprssystemdialog.ui" line="192"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../src/main.cc" line="25"/>
+        <source>Codeplug file to load.</source>
+        <translation>Файл кодплага для загрузки.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cc" line="26"/>
+        <source>Specifies applications log-level to stdout. Must be one of `debug`, `info`, `warning`, `error` or `fatal`.</source>
+        <translation>Уровень журнала в stdout: `debug`, `info`, `warning`, `error` или `fatal`.</translation>
+    </message>
+</context>
+</TS>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,7 +79,8 @@ qt6_add_translations(qdmr TS_FILES
   ${PROJECT_SOURCE_DIR}/i18n/de.ts ${PROJECT_SOURCE_DIR}/i18n/en_US.ts
   ${PROJECT_SOURCE_DIR}/i18n/sv.ts ${PROJECT_SOURCE_DIR}/i18n/it.ts
   ${PROJECT_SOURCE_DIR}/i18n/nl.ts ${PROJECT_SOURCE_DIR}/i18n/pl.ts
-  ${PROJECT_SOURCE_DIR}/i18n/fr.ts ${PROJECT_SOURCE_DIR}/i18n/pt_BR.ts)
+  ${PROJECT_SOURCE_DIR}/i18n/fr.ts ${PROJECT_SOURCE_DIR}/i18n/pt_BR.ts
+  ${PROJECT_SOURCE_DIR}/i18n/ru_RU.ts)
 
 #
 # Icon generation

--- a/src/application.cc
+++ b/src/application.cc
@@ -45,10 +45,10 @@
 
 
 
-inline QStringList getLanguages() {
+static QStringList systemLocaleCandidates() {
   QStringList languages = {QLocale::system().name()};
-  if (languages.last().contains("_")) {
-    languages.append(languages.last().split("_").first());
+  if (languages.last().contains(QLatin1Char('_'))) {
+    languages.append(languages.last().split(QLatin1Char('_')).first());
   }
   return languages;
 }
@@ -75,17 +75,14 @@ Application::Application(int &argc, char *argv[])
 
   // handle translations
   _translator = new QTranslator(this);
-  foreach (QString language, getLanguages()) {
-    logDebug() << "Search for translation in ':/i18n/" << language << ".qm'.";
-    if (_translator->load(language, ":/i18n/", "", ".qm")) {
-      this->installTranslator(_translator);
-      logDebug() << "Installed translator for locale '" << QLocale::system().name() << "'.";
-      break;
-    }
+  Settings settings;
+  {
+    const QString langPref =
+        settings.uiLanguage().isEmpty() ? QStringLiteral("system") : settings.uiLanguage();
+    loadLanguage(langPref);
   }
 
-  // load settings
-  Settings settings;
+  // load settings (same Settings instance as above)
   // load databases
   _repeater   = new RepeaterDatabase(this);
   if (settings.repeaterBookSourceEnabled())
@@ -917,3 +914,41 @@ Application::onPaletteChanged(const QPalette &palette) {
 }
 
 
+bool
+Application::loadLanguage(const QString &localeId) {
+  removeTranslator(_translator);
+  bool loaded = false;
+  const bool useSystemLocale =
+      localeId.isEmpty() || localeId == QStringLiteral("system");
+
+  if (! useSystemLocale) {
+    logDebug() << "Try translation ':/i18n/" << localeId << ".qm'.";
+    loaded = _translator->load(localeId, QStringLiteral(":/i18n/"), QString(), QStringLiteral(".qm"));
+    if (! loaded && localeId.contains(QLatin1Char('_'))) {
+      const QString shortTag = localeId.split(QLatin1Char('_')).first();
+      loaded = _translator->load(shortTag, QStringLiteral(":/i18n/"), QString(), QStringLiteral(".qm"));
+    }
+  } else {
+    foreach (const QString &cand, systemLocaleCandidates()) {
+      logDebug() << "Try system translation ':/i18n/" << cand << ".qm'.";
+      loaded = _translator->load(cand, QStringLiteral(":/i18n/"), QString(), QStringLiteral(".qm"));
+      if (loaded)
+        break;
+    }
+  }
+
+  if (! loaded) {
+    logDebug() << "Fallback to ':/i18n/en_US.qm'.";
+    loaded = _translator->load(QStringLiteral("en_US"), QStringLiteral(":/i18n/"), QString(),
+                               QStringLiteral(".qm"));
+  }
+
+  if (loaded) {
+    installTranslator(_translator);
+    logDebug() << "Installed translator for UI language preference '" << localeId << "'.";
+  } else {
+    logError() << "Failed to load any translation.";
+  }
+
+  return loaded;
+}

--- a/src/application.hh
+++ b/src/application.hh
@@ -89,6 +89,9 @@ private slots:
 
   void onPaletteChanged(const QPalette &palette);
 
+private:
+  bool loadLanguage(const QString &localeId);
+
 protected:
   Config *_config;
   MainWindow *_mainWindow;

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -1,5 +1,6 @@
 #include "mainwindow.hh"
 #include "ui_mainwindow.h"
+#include <QActionGroup>
 #include <QProgressBar>
 #include <QCloseEvent>
 #include <QMessageBox>
@@ -26,7 +27,7 @@
 
 
 MainWindow::MainWindow(Config *config, QWidget *parent)
-  : QMainWindow(parent), ui(new Ui::MainWindow)
+  : QMainWindow(parent), ui(new Ui::MainWindow), _languageGroup(nullptr)
 {
   ui->setupUi(this);
   Application *app = qobject_cast<Application*>(QApplication::instance());
@@ -102,6 +103,45 @@ MainWindow::MainWindow(Config *config, QWidget *parent)
   connect(ui->actionUpload, SIGNAL(triggered()), app, SLOT(uploadCodeplug()));
   connect(ui->actionWriteSatellites, SIGNAL(triggered()), app, SLOT(uploadSatellites()));
 
+  _languageGroup = new QActionGroup(this);
+  _languageGroup->setExclusive(true);
+  ui->menuLanguage->clear();
+  // Locale ids match basenames of i18n/*.ts shipped as :/i18n/*.qm
+  static const struct {
+    const char *id;
+    const char *label;
+  } kUiLanguages[] = {
+      {"system", QT_TR_NOOP("System default")},
+      {"de", QT_TR_NOOP("German")},
+      {"en_US", QT_TR_NOOP("English")},
+      {"fr", QT_TR_NOOP("French")},
+      {"it", QT_TR_NOOP("Italian")},
+      {"nl", QT_TR_NOOP("Dutch")},
+      {"pl", QT_TR_NOOP("Polish")},
+      {"pt_BR", QT_TR_NOOP("Portuguese (Brazil)")},
+      {"ru_RU", QT_TR_NOOP("Russian")},
+      {"sv", QT_TR_NOOP("Swedish")},
+  };
+  for (const auto &entry : kUiLanguages) {
+    const QString id = QString::fromLatin1(entry.id);
+    QAction *a = ui->menuLanguage->addAction(tr(entry.label));
+    a->setCheckable(true);
+    a->setData(id);
+    _languageGroup->addAction(a);
+    QObject::connect(a, &QAction::triggered, this, [this, id]() {
+      const QString before =
+          Settings().uiLanguage().isEmpty() ? QStringLiteral("system") : Settings().uiLanguage();
+      Settings().setUiLanguage(id);
+      updateLanguageMenuChecks();
+      if (before != id) {
+        QMessageBox::information(
+              this, tr("Language"),
+              tr("The language will be applied fully after you restart the application."));
+      }
+    });
+  }
+  updateLanguageMenuChecks();
+
   // Wire-up "General Settings" view
   _generalSettings = new GeneralSettingsView(config);
   ui->tabs->addTab(_generalSettings, tr("Settings"));
@@ -136,6 +176,21 @@ MainWindow::MainWindow(Config *config, QWidget *parent)
   connect(config, &ConfigItem::modified, [this, config]() {
     this->setWindowModified(config->isModified());
   });
+}
+
+
+void
+MainWindow::updateLanguageMenuChecks() {
+  const QString sel =
+      Settings().uiLanguage().isEmpty() ? QStringLiteral("system") : Settings().uiLanguage();
+  for (QAction *a : _languageGroup->actions()) {
+    if (a->data().toString() == sel) {
+      a->setChecked(true);
+      return;
+    }
+  }
+  if (!_languageGroup->actions().isEmpty())
+    _languageGroup->actions().first()->setChecked(true);
 }
 
 

--- a/src/mainwindow.hh
+++ b/src/mainwindow.hh
@@ -3,6 +3,8 @@
 
 #include <QMainWindow>
 
+class QActionGroup;
+
 class Config;
 class GeneralSettingsView;
 class RadioIDListView;
@@ -24,7 +26,10 @@ protected:
   void closeEvent(QCloseEvent *event);
 
 private:
+  void updateLanguageMenuChecks();
+
   Ui::MainWindow *ui;
+  QActionGroup *_languageGroup;
   GeneralSettingsView *_generalSettings;
   RadioIDListView *_radioIdTab;
   RoamingZoneListView *_roamingZoneList;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -109,9 +109,15 @@
     <addaction name="actionRefreshOrbitalElements"/>
     <addaction name="actionEditSatellites"/>
    </widget>
+   <widget class="QMenu" name="menuLanguage">
+    <property name="title">
+     <string>Language</string>
+    </property>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuDevice"/>
    <addaction name="menuDatabases"/>
+   <addaction name="menuLanguage"/>
    <addaction name="menuHelp"/>
   </widget>
   <widget class="QStatusBar" name="statusbar">

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -301,6 +301,16 @@ Settings::setShowDisclaimer(bool show) {
   setValue("showDisclaimer", show);
 }
 
+QString
+Settings::uiLanguage() const {
+  return value("uiLanguage", QStringLiteral("system")).toString();
+}
+
+void
+Settings::setUiLanguage(const QString &localeId) {
+  setValue("uiLanguage", localeId);
+}
+
 ConfigMergeVisitor::ItemStrategy
 Settings::configMergeItemStrategy() const {
   return (ConfigMergeVisitor::ItemStrategy)value(

--- a/src/settings.hh
+++ b/src/settings.hh
@@ -97,6 +97,10 @@ public:
   bool showDisclaimer() const;
   void setShowDisclaimer(bool show);
 
+  /// Application UI language: `"system"` or a locale tag matching `i18n/*.qm` (e.g. `en_US`, `de`, `ru_RU`).
+  QString uiLanguage() const;
+  void setUiLanguage(const QString &localeId);
+
   ConfigMergeVisitor::ItemStrategy configMergeItemStrategy() const;
   void setConfigMergeItemStrategy(ConfigMergeVisitor::ItemStrategy strategy);
 


### PR DESCRIPTION
This PR adds a simple persistent UI language selection menu.

Changes:
- adds a uiLanguage setting
- loads the selected translation at startup
- adds a Language menu in the main window
- keeps language changes restart-based for simplicity and safety

Behavior:
- the selected language is saved in settings
- the language is fully applied after restart
- System default preserves the existing locale-based behavior

Additionally, this branch includes initial Russian (ru_RU) translation support.