### PR TITLE
DM-32UV: fix channel bit field mappings and uninitialized memory

### DIFF
--- a/lib/dm32uv_codeplug.cc
+++ b/lib/dm32uv_codeplug.cc
@@ -80,7 +80,7 @@ DM32UVCodeplug::ChannelElement::setChannelType(ChannelType type) {
 
 Channel::Power
 DM32UVCodeplug::ChannelElement::power() const {
-  switch ((Power)getUInt2(Offset::power())) {
+  switch ((Power)getUInt4(Offset::power())) {
   case Power::Low: return Channel::Power::Low;
   case Power::Medium: return Channel::Power::Mid;
   case Power::High: return Channel::Power::High;
@@ -93,14 +93,14 @@ DM32UVCodeplug::ChannelElement::setPower(Channel::Power power) {
   switch (power) {
   case Channel::Power::Min:
   case Channel::Power::Low:
-    setUInt2(Offset::power(), (unsigned int)Power::Low);
+    setUInt4(Offset::power(), (unsigned int)Power::Low);
     break;
   case Channel::Power::Mid:
-    setUInt2(Offset::power(), (unsigned int)Power::Medium);
+    setUInt4(Offset::power(), (unsigned int)Power::Medium);
     break;
   case Channel::Power::High:
   case Channel::Power::Max:
-    setUInt2(Offset::power(), (unsigned int)Power::High);
+    setUInt4(Offset::power(), (unsigned int)Power::High);
     break;
   }
 }
@@ -231,12 +231,12 @@ DM32UVCodeplug::ChannelElement::clearEmergencySystemIndex() {
 
 Level
 DM32UVCodeplug::ChannelElement::squelchLevel() const {
-  return Level::fromValue(getUInt4(Offset::squelchLevel()), Limit::squelchLevel());
+  return Level::fromValue(getUInt8(Offset::squelchLevel()), Limit::squelchLevel());
 }
 
 void
 DM32UVCodeplug::ChannelElement::setSquelchLevel(Level level) {
-  setUInt4(Offset::squelchLevel(), level.mapTo(Limit::squelchLevel()));
+  setUInt8(Offset::squelchLevel(), level.mapTo(Limit::squelchLevel()));
 }
 
 
@@ -4342,6 +4342,7 @@ DM32UVCodeplug::encodeChannels(Context &ctx, const ErrorStack &err) {
                                         : blockNumber * ChannelBankElement::Offset::betweenChannelBlocks())
                     + indexInBlock * ChannelElement::size();
     // Create channel
+    ChannelElement(data(addr)).fill(0x00);
     if (! ChannelElement(data(addr)).encode(ctx.get<Channel>(i), ctx, err)) {
       errMsg(err) << "Cannot encode channel at index " << i << ".";
       return false;
@@ -4363,6 +4364,7 @@ DM32UVCodeplug::encodeChannels(Context &ctx, const ErrorStack &err) {
     uint32_t addr = Offset::channelExtensionBanks()
         + blockNumber * ChannelExtensionBankElement::Offset::betweenBanks()
         + indexInBlock * ChannelExtensionElement::size();
+    ChannelExtensionElement(data(addr)).fill(0x00);
     if (! ChannelExtensionElement(data(addr)).encode(ctx.get<Channel>(i), ctx, err)) {
       errMsg(err) << "Cannot encode channel extension at index " << i << ".";
       return false;

--- a/lib/dm32uv_codeplug.hh
+++ b/lib/dm32uv_codeplug.hh
@@ -243,7 +243,7 @@ public:
       static constexpr unsigned int rxFrequency() { return 0x0010; }
       static constexpr unsigned int txFrequency() { return 0x0014; }
       static constexpr Bit channelType()          { return {0x0018, 4}; }
-      static constexpr Bit power()                { return {0x0018, 1}; }
+      // 0x18 bits 2-1: busy lock (not yet implemented)
       static constexpr Bit loneWorker()           { return {0x0018, 0}; }
       static constexpr Bit bandwidth()            { return {0x0019, 7}; }
       static constexpr Bit scanListIndex()        { return {0x0019, 2}; }
@@ -253,14 +253,15 @@ public:
       static constexpr Bit emergencyNotification() { return {0x001b, 7}; }
       static constexpr Bit emergencyACK()         { return {0x001b, 6}; }
       static constexpr Bit emergencySystemIndex() { return {0x001b, 0}; }
-      static constexpr Bit squelchLevel()         { return {0x001c, 4}; }
-      static constexpr Bit rxOnly()               { return {0x001c, 3}; }
+      static constexpr Bit power()                { return {0x001c, 4}; }
+      static constexpr Bit rxOnly()               { return {0x0018, 3}; }
       static constexpr Bit dmrAPRS()              { return {0x001c, 2}; }
       static constexpr Bit privateCallACK()       { return {0x001d, 7}; }
       static constexpr Bit dataACK()              { return {0x001d, 6}; }
       static constexpr Bit dcdm()                 { return {0x001d, 5}; }
       static constexpr Bit timeslot()             { return {0x001d, 4}; }
       static constexpr Bit colorcode()            { return {0x001d, 0}; }
+      static constexpr unsigned int squelchLevel()  { return 0x001e; }
       static constexpr Bit encryptionEnable()     { return {0x001f, 6}; }
       static constexpr Bit groupListIndex()       { return {0x001f, 0}; }
       static constexpr Bit dmrAPRSChannelIndex()  { return {0x0020, 0}; }


### PR DESCRIPTION
Fixes three incorrect channel element bit field positions and adds memory initialization for new channels.

## Bugs fixed

1. **rxOnly (Forbid TX) at wrong byte** — was mapped to `0x1C:3`, hardware uses `0x18:3`. New channels had the Forbid TX bit left uninitialized, causing the radio to randomly block TX with "RX only" on newly-added channels.

2. **power at wrong byte and width** — was mapped to `0x18` bits 2-1 (2-bit), hardware uses `0x1C` bits 7-4 (4-bit). The position `0x18` bits 2-1 is actually busy lock. Power level changes from qdmr had no effect on the radio.

3. **squelchLevel at wrong byte and width** — was mapped to `0x1C` bits 7-4 (4-bit), hardware uses `0x1E` as a full byte. Squelch was being written to the power/APRS byte.

4. **New channel memory uninitialized** — `encodeChannels()` allocated memory for new channel elements and extensions but never zeroed it before calling `encode()`. Fields that `encode()` does not explicitly set retained garbage data from previous codeplug contents, causing the radio to reject new channels with "Style is err".

## Verification

Correct field positions verified against the independently reverse-engineered [DM32 Protocol Spec](https://github.com/infamy/DM32-Protocol-Spec/blob/master/05-DATA-STRUCTURES.md) by infamy.

Tested on a Baofeng DM-32UV (firmware DM32.00.01.048) with an AURSINC MMDVM Duplex hotspot. Before the fix, new DMR channels showed "RX only" on PTT and "Style is err". After the fix, TX works correctly on all new channels.