### PR TITLE
Fix opengd77 settings write

### DIFF
--- a/lib/openuv380_satelliteconfig.cc
+++ b/lib/openuv380_satelliteconfig.cc
@@ -1,5 +1,6 @@
 #include "openuv380_satelliteconfig.hh"
 #include "errorstack.hh"
+#include "logger.hh"
 
 
 OpenUV380SatelliteConfig::OpenUV380SatelliteConfig(QObject *parent)
@@ -25,8 +26,24 @@ bool
 OpenUV380SatelliteConfig::encode(SatelliteDatabase *db, const ErrorStack &err) {
   OpenGD77BaseCodeplug::AdditionalSettingsElement settings(data(Offset::satellites(), FLASH));
   if (! settings.isValid()) {
-    errMsg(err) << "Cannot encode satellite config for OpenUV380: Invalid settings element.";
-    return false;
+    QString magic = settings.magic();
+    unsigned int version = settings.version();
+    // Only refuse when a real "OpenGD77" header is present with an unknown
+    // version: that's a newer firmware format we must not trash. Anything else
+    // (virgin flash 0xff, leftovers from a previous firmware, factory garbage)
+    // is fair game — the firmware itself ignores the region without the magic.
+    if (magic == "OpenGD77") {
+      errMsg(err) << "Refusing to overwrite OpenGD77 additional-settings region: "
+                  << "version " << version << " is not supported (expected 1). "
+                  << "The radio firmware may be newer than this qdmr build.";
+      return false;
+    }
+    logDebug() << "OpenUV380 additional-settings region at 0x"
+               << QString::number(Offset::satellites(), 16)
+               << " has no valid header (magic='" << magic
+               << "', version=" << version << "). "
+               << "Initializing OpenGD77 settings header.";
+    settings.clear();
   }
 
   OpenGD77BaseCodeplug::SatelliteBankElement bank = settings.satellites();


### PR DESCRIPTION
Fixes the writing of satellite data initializing the OpenGD77 settings area when not initialized, at least in my firmware it seemed to be not initialized in any way.

This PR initialize the settings area if not initialized.


Fixes-Issue: https://github.com/hmatuschek/qdmr/issues/960