### PR TITLE
logger: add TRACE level and use it for raw IO dumps in OpenGD77

### DIFF
--- a/cli/main.cc
+++ b/cli/main.cc
@@ -40,7 +40,12 @@ int main(int argc, char *argv[])
   parser.addVersionOption();
   parser.addOption({
                      {"V","verbose"},
-                     QCoreApplication::translate("main", "Verbose output.")
+                     QCoreApplication::translate("main", "Verbose output (alias for --loglevel debug).")
+                   });
+  parser.addOption({
+                     "loglevel",
+                     QCoreApplication::translate("main", "Specifies the log-level to stderr. Must be one of `trace`, `debug`, `info`, `warning`, `error` or `fatal`."),
+                     "loglevel", "warning"
                    });
   parser.addOption({
                      {"c", "csv"},
@@ -168,8 +173,17 @@ int main(int argc, char *argv[])
   if (1 > parser.positionalArguments().size())
     parser.showHelp(-1);
 
-  if (parser.isSet("verbose"))
+  if (parser.isSet("loglevel")) {
+    QString lvl = parser.value("loglevel").toLower();
+    if ("trace" == lvl)        handler->setMinLevel(LogMessage::TRACE);
+    else if ("debug" == lvl)   handler->setMinLevel(LogMessage::DEBUG);
+    else if ("info" == lvl)    handler->setMinLevel(LogMessage::INFO);
+    else if ("warning" == lvl) handler->setMinLevel(LogMessage::WARNING);
+    else if ("error" == lvl)   handler->setMinLevel(LogMessage::ERROR);
+    else if ("fatal" == lvl)   handler->setMinLevel(LogMessage::FATAL);
+  } else if (parser.isSet("verbose")) {
     handler->setMinLevel(LogMessage::DEBUG);
+  }
 
   int res = -1;
   QString command = parser.positionalArguments().at(0);

--- a/lib/logger.cc
+++ b/lib/logger.cc
@@ -142,6 +142,11 @@ StreamLogHandler::handle(const LogMessage &message) {
   if (message.level() < _minLevel)
     return;
   switch (message.level()) {
+  case LogMessage::TRACE:
+    if (_color)
+      _stream << "\033[37m";
+    _stream << "Trace ";
+    break;
   case LogMessage::DEBUG:
     if (_color)
       _stream << "\033[37m";
@@ -231,6 +236,7 @@ FileLogHandler::handle(const LogMessage &message) {
 
   _stream << QDateTime::currentDateTime().toString(Qt::ISODateWithMs) << ": ";
   switch (message.level()) {
+  case LogMessage::TRACE:   _stream << "Trace "; break;
   case LogMessage::DEBUG:   _stream << "Debug "; break;
   case LogMessage::INFO:    _stream << "Info "; break;
   case LogMessage::WARNING: _stream << "Warning "; break;

--- a/lib/logger.hh
+++ b/lib/logger.hh
@@ -8,6 +8,8 @@
 #include <QList>
 #include <QMutex>
 
+/** Constructs a trace message. */
+#define logTrace() LogMessage(LogMessage::TRACE, __FILE__, __LINE__)
 /** Constructs a debug message. */
 #define logDebug() LogMessage(LogMessage::DEBUG, __FILE__, __LINE__)
 /** Constructs an info message. */
@@ -34,6 +36,7 @@ class LogMessage: public QTextStream
 public:
   /** Possible log-levels. */
   typedef enum {
+    TRACE,    ///< Level for very verbose trace messages (e.g. raw IO dumps). Not shown unless requested.
     DEBUG,    ///< Level for debug messages. Will not be shown to the user unless requested.
     INFO,     ///< Level for informative messages. Will not be shown to the user unless requested.
     WARNING,  ///< Level for warning messages.

--- a/lib/opengd77_interface.cc
+++ b/lib/opengd77_interface.cc
@@ -497,7 +497,10 @@ OpenGD77Interface::readEEPROM(uint32_t addr, uint8_t *data, uint16_t len, const 
     return false;
   }
 
-  memcpy(data, resp.data, qFromBigEndian(resp.length));
+  uint16_t respLen = qFromBigEndian(resp.length);
+  memcpy(data, resp.data, respLen);
+  logTrace() << "EEPROM read 0x" << QString::number(addr, 16) << " (" << respLen
+             << " bytes): " << QByteArray((const char *)data, respLen).toHex(' ');
   return true;
 }
 
@@ -583,7 +586,10 @@ OpenGD77Interface::readFlash(uint32_t addr, uint8_t *data, uint16_t len, const E
     return false;
   }
 
-  memcpy(data, resp.data, qFromBigEndian(resp.length));
+  uint16_t respLen = qFromBigEndian(resp.length);
+  memcpy(data, resp.data, respLen);
+  logTrace() << "FLASH read 0x" << QString::number(addr, 16) << " (" << respLen
+             << " bytes): " << QByteArray((const char *)data, respLen).toHex(' ');
   return true;
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -23,7 +23,7 @@ int main(int argc, char *argv[])
   parser.addHelpOption();
   parser.addVersionOption();
   parser.addPositionalArgument("codeplug", QCoreApplication::translate("main", "Codeplug file to load."));
-  parser.addOption({"loglevel", QCoreApplication::translate("main", "Specifies applications log-level to stdout. Must be one of `debug`, `info`, `warning`, `error` or `fatal`."), "loglevel", "info"});
+  parser.addOption({"loglevel", QCoreApplication::translate("main", "Specifies applications log-level to stdout. Must be one of `trace`, `debug`, `info`, `warning`, `error` or `fatal`."), "loglevel", "info"});
   parser.parse(app.arguments());
 
   // Handle args (if there are some)
@@ -34,15 +34,18 @@ int main(int argc, char *argv[])
   }
 
   if (parser.isSet("loglevel")) {
-    if ("debug" == parser.value("loglevel")) {
+    QString lvl = parser.value("loglevel").toLower();
+    if ("trace" == lvl) {
+      handler->setMinLevel(LogMessage::Level::TRACE);
+    } else if ("debug" == lvl) {
       handler->setMinLevel(LogMessage::Level::DEBUG);
-    } else if ("info" == parser.value("loglevel")) {
+    } else if ("info" == lvl) {
       handler->setMinLevel(LogMessage::Level::INFO);
-    } else if ("warning" == parser.value("loglevel")) {
+    } else if ("warning" == lvl) {
       handler->setMinLevel(LogMessage::Level::WARNING);
-    } else if ("error" == parser.value("loglevel")) {
+    } else if ("error" == lvl) {
       handler->setMinLevel(LogMessage::Level::ERROR);
-    } else if ("fatal" == parser.value("loglevel")) {
+    } else if ("fatal" == lvl) {
       handler->setMinLevel(LogMessage::Level::FATAL);
     }
   }


### PR DESCRIPTION
Introduce a new log level below DEBUG (TRACE) plus a logTrace() macro, and surface it via `qdmr --loglevel trace` and `dmrconf --loglevel trace`.

`--loglevel` now takes the argument toLower(), just in case the user provides DEBUG/TRACE/INFO/etc instead of debug/trace/info.

 Use logTrace() in opengd77_interface to dump every EEPROM/FLASH read as hex, hidden behind the new level so the existing logs stay clean.

