### PR TITLE
opengd77: expose locationEnabled (LOC) channel flag

### DIFF
--- a/lib/opengd77_extension.hh
+++ b/lib/opengd77_extension.hh
@@ -30,6 +30,8 @@ class OpenGD77ChannelExtension: public ConfigExtension
   Q_PROPERTY(bool beep READ beep WRITE enableBeep)
   /** The power save enable flag. */
   Q_PROPERTY(bool powerSave READ powerSave WRITE enablePowerSave)
+  /** If @c true, the fixed location is used for the APRS report instead of GPS. */
+  Q_PROPERTY(bool locationEnabled READ locationEnabled WRITE enableLocation)
   /** Sets a fixed location for the APRS report. */
   Q_PROPERTY(QString location READ locator WRITE setLocator)
   /** Sets the talker alias for timeslot 1. */


### PR DESCRIPTION
The OpenGD77 firmware's per-channel "use fixed location" (LOC) flag was already wired through OpenGD77ChannelExtension and the codeplug (useFixedLocation bit), but lacked a Q_PROPERTY declaration so it never appeared in the qDMR extension editor or in YAML (de)serialization for dmrconf.

This flag is used by the OpenGD77 firmware to use the location for roaming or distance calculation to a repeater, it needs to be enabled to make the location effective.

Closes-Issue: #965