### PR TITLE
Fix DCS decoding/encoding for DM32UV

### DIFF
--- a/lib/dm32uv_codeplug.cc
+++ b/lib/dm32uv_codeplug.cc
@@ -632,8 +632,8 @@ DM32UVCodeplug::ChannelElement::decodeSelectiveCall(uint16_t code) {
   if (0 == type) {
     return SelectiveCall(double((code>>12)&0xf)*100 + double((code>>8)&0xf)*10
       + double((code>>4)&0xf)*1 + double(code & 0xf)/10);
-  } else if ((1 == type) || (2 == type)) {
-    return SelectiveCall(code, 2 == type);
+  } else if ((2 == type) || (3 == type)) {
+    return SelectiveCall(((code>>8)&0xf)*100 + ((code>>4)&0xf)*10 + (code & 0xf), 3 == type);
   }
 
   return SelectiveCall();
@@ -648,7 +648,10 @@ DM32UVCodeplug::ChannelElement::encodeSelectiveCall(const SelectiveCall &tone) {
       | (((tone.mHz()/10000) % 10) << 8)
       | (((tone.mHz()/1000) % 10) << 4) | ((tone.mHz()/100) % 10);
   if (tone.isDCS())
-    return ((tone.isInverted() ? 2 : 1) << 14) | tone.octalCode();
+    return ((tone.isInverted() ? 3 : 2) << 14)
+      | (((tone.binCode()/64) % 8) << 8)
+      | (((tone.binCode()/8) % 8) << 4)
+      | (tone.binCode() % 8);
   return 0xffff;
 }
 

--- a/lib/dm32uv_codeplug.cc
+++ b/lib/dm32uv_codeplug.cc
@@ -625,6 +625,7 @@ DM32UVCodeplug::ChannelElement::decodeSelectiveCall(uint16_t code) {
   if (0xffff == code)
     return SelectiveCall();
 
+  logTrace() << "Selective Call word: " << Qt::hex << code;
   uint8_t type = code >> 14;
   code &= 0x3fff;
 


### PR DESCRIPTION
Testing support for the DM32UV handset using a codeplug based on the following CHIRP channel set:
[Baofeng standard channels.csv](https://github.com/user-attachments/files/29323266/Baofeng.standard.channels.csv)
I'm just using it to test because of the different CTCSS and DCS settings.

After debugging the codeplug parsing, I found and fixed two issues.

1. Fixed processing of selective call type bits.  A type value of 2 indicates normal DCS, a value of 3 indicates inverted DCS.
2. The octal value of the DCS code is stored in packed 4-bit BCD form, similar to CTCSS frequency.

After fixing these two issues in both the decoder and encoder, I can successfully read and write all the selective call settings in the test channels.