### PR TITLE
AnyTone: don't infer the boot-password enable flag from the password string

### DIFF
--- a/lib/anytone_codeplug.cc
+++ b/lib/anytone_codeplug.cc
@@ -2245,7 +2245,12 @@ AnytoneCodeplug::BootSettingsElement::updateConfig(Context &ctx) {
   ctx.config()->settings()->boot()->setMessage2(introLine2());
 
   ctx.config()->settings()->boot()->setBootPassword(password());
-  ctx.config()->settings()->boot()->enableBootPassword(! password().isEmpty());
+  // Do NOT derive the enabled-flag from the password string here. The radio stores
+  // that flag separately, in the general settings, and it is already decoded by
+  // GeneralSettingsElement::updateConfig(), which runs before this element. A radio
+  // may well hold a non-empty but *disabled* boot password; inferring "enabled" from
+  // "password is not empty" overwrites the correct flag, and the next write then
+  // enables the password and locks the user out of their radio.
 
   return true;
 }


### PR DESCRIPTION
Writing a codeplug that was read straight back from an AnyTone radio can enable the boot password and lock the owner out. No boot setting has to be touched. A read, an unrelated edit and a write is enough. It happened to me on an AT-D878UVII.

`BootSettingsElement::updateConfig()` derives the enable flag from whether the stored password string is non-empty:

```cpp
ctx.config()->settings()->boot()->setBootPassword(password());
ctx.config()->settings()->boot()->enableBootPassword(! password().isEmpty());
```

The radio keeps that flag separately, in the general settings, and it's already decoded by `GeneralSettingsElement::updateConfig()`. That one runs first: `D868UVCodeplug::createElements()` calls `decodeGeneralSettings()` before `decodeBootSettings()`. So the inference above overwrites a flag that was decoded correctly a moment earlier.

My radio had a password stored but switched off. A codeplug I saved from it in February shows exactly that:

```yaml
anytone:
  bootSettings:
    bootPasswordEnabled: false
    bootPassword: 12345678
```

Reading the same radio with 0.15.1 produced `settings.boot.passwordEnabled: true`, and writing that back turned the password on. After that the radio wouldn't enter program mode at all until the password was typed in on the keypad, so recovering it needed the password first.

This patch drops the inference and lets the decoded flag stand. The encode side already writes the password only when it's enabled, so nothing else changes.

The 27 unit tests still pass. I haven't re-run the patched build against the radio, because reproducing the original state means deliberately locking a radio again, which I'd rather not do to mine.
