### PR TITLE
Round instead of truncating when mapping between Level ranges

### DIFF
--- a/lib/codeplug.hh
+++ b/lib/codeplug.hh
@@ -104,10 +104,17 @@ public:
         inline bool in(const T &value) const {
           return (value <= max) && (value >= min);
         }
-        /** Maps a value from this range to the given range. */
+        /** Maps a value from this range to the given range.
+         * Rounds to the nearest value rather than truncating. Truncating in both
+         * directions makes @c Level round-trips lossy: reading a setting from the
+         * radio and writing it back unchanged shifts it down (e.g. mic gain 1 -> 0,
+         * volume 6 -> 5), so every read-modify-write cycle walks such settings
+         * towards their minimum. */
         inline T mapTo(const Range<T> &other, const T &value) const {
           T myD = max-min, oD = other.max-other.min;
-          return ((limit(value)-min)*oD)/myD + other.min;
+          if (0 == myD)
+            return other.min;
+          return ((limit(value)-min)*oD + myD/2)/myD + other.min;
         }
       };
     };

--- a/test/d578uv_test.cc
+++ b/test/d578uv_test.cc
@@ -157,7 +157,10 @@ D578UVTest::testMicGain() {
   // FM mic gain enabled only if it differs from DMR gain
   QVERIFY(! copy.settings()->audio()->fmMicGainEnabled());
 
-  QList<QPair<unsigned int,unsigned int>> pairs = {{1,1}, {2,1}, {3,1}, {4,3}, {5,3}, {6,5}, {7,5}, {8,7}, {9,7}, {10,10}};
+  // The radio stores 5 mic-gain steps, so the 1-10 level is quantized to the nearest
+  // representable step. Every value the radio can produce ({1,3,6,8,10}) must map to
+  // itself: a level read from a radio has to survive being written back unchanged.
+  QList<QPair<unsigned int,unsigned int>> pairs = {{1,1}, {2,1}, {3,3}, {4,3}, {5,6}, {6,6}, {7,8}, {8,8}, {9,10}, {10,10}};
   for (auto pair: pairs) {
     config.settings()->audio()->setMicGain(Level::fromValue(pair.first));
     encodeDecode(config, copy);

--- a/test/d868uve_test.cc
+++ b/test/d868uve_test.cc
@@ -367,7 +367,10 @@ void
 D868UVETest::testMicGain() {
   ErrorStack err;
   Config copy, config; config.copy(_basicConfig);
-  QList<QPair<unsigned int,unsigned int>> pairs = {{1,1}, {2,1}, {3,1}, {4,3}, {5,3}, {6,5}, {7,5}, {8,7}, {9,7}, {10,10}};
+  // The radio stores 5 mic-gain steps, so the 1-10 level is quantized to the nearest
+  // representable step. Every value the radio can produce ({1,3,6,8,10}) must map to
+  // itself: a level read from a radio has to survive being written back unchanged.
+  QList<QPair<unsigned int,unsigned int>> pairs = {{1,1}, {2,1}, {3,3}, {4,3}, {5,6}, {6,6}, {7,8}, {8,8}, {9,10}, {10,10}};
   for (auto pair: pairs) {
     config.settings()->audio()->setMicGain(Level::fromValue(pair.first));
     encodeDecode(config, copy);

--- a/test/d878uv_test.cc
+++ b/test/d878uv_test.cc
@@ -71,7 +71,9 @@ D878UVTest::testAnalogMicGain() {
   Config config;
   encodeDecode(_micGainConfig, config);
   QVERIFY(config.settings()->audio()->fmMicGainEnabled());
-  QCOMPARE(config.settings()->audio()->fmMicGain(), Level::fromValue(5));
+  // The fixture sets fmMicGain: 6, which is representable on this radio, so it must
+  // survive the round-trip unchanged (it used to come back as 5).
+  QCOMPARE(config.settings()->audio()->fmMicGain(), Level::fromValue(6));
 }
 
 void
@@ -593,7 +595,10 @@ void
 D878UVTest::testMicGain() {
   ErrorStack err;
   Config copy, config; config.copy(_basicConfig);
-  QList<QPair<unsigned int,unsigned int>> pairs = {{1,1}, {2,1}, {3,1}, {4,3}, {5,3}, {6,5}, {7,5}, {8,7}, {9,7}, {10,10}};
+  // The radio stores 5 mic-gain steps, so the 1-10 level is quantized to the nearest
+  // representable step. Every value the radio can produce ({1,3,6,8,10}) must map to
+  // itself: a level read from a radio has to survive being written back unchanged.
+  QList<QPair<unsigned int,unsigned int>> pairs = {{1,1}, {2,1}, {3,3}, {4,3}, {5,6}, {6,6}, {7,8}, {8,8}, {9,10}, {10,10}};
   for (auto pair: pairs) {
     config.settings()->audio()->setMicGain(Level::fromValue(pair.first));
     encodeDecode(config, copy);

--- a/test/dmr6x2uv_test.cc
+++ b/test/dmr6x2uv_test.cc
@@ -253,7 +253,10 @@ void
 DMR6X2UVTest::testMicGain() {
   ErrorStack err;
   Config copy, config; config.copy(_basicConfig);
-  QList<QPair<unsigned int,unsigned int>> pairs = {{1,1}, {2,1}, {3,1}, {4,3}, {5,3}, {6,5}, {7,5}, {8,7}, {9,7}, {10,10}};
+  // The radio stores 5 mic-gain steps, so the 1-10 level is quantized to the nearest
+  // representable step. Every value the radio can produce ({1,3,6,8,10}) must map to
+  // itself: a level read from a radio has to survive being written back unchanged.
+  QList<QPair<unsigned int,unsigned int>> pairs = {{1,1}, {2,1}, {3,3}, {4,3}, {5,6}, {6,6}, {7,8}, {8,8}, {9,10}, {10,10}};
   for (auto pair: pairs) {
     config.settings()->audio()->setMicGain(Level::fromValue(pair.first));
     encodeDecode(config, copy);


### PR DESCRIPTION
`Range::mapTo()` truncates. `Level` holds a 1-10 value and maps it onto the radio's raw range when writing, then back again when reading, so truncating in both directions makes the round-trip lossy. A setting read from a radio and written back untouched comes back lower than it started.

I hit this on an AT-D878UVII, where mic gain has the range `{0,4}`. The radio held raw 1, which reads as level 3. Writing that level back unchanged stored raw 0, which reads as level 1. I only noticed because I wrote a codeplug back verbatim and the mic gain had moved.

The maximum of each range is a fixed point, but the intermediate values aren't, so repeated read-edit-write cycles walk these settings down towards the minimum. Volume goes 6, 5, 4, 3, 2, 1 over successive writes.

Rounding to nearest fixes it. Across the level ranges actually used in the tree, the number of values that don't survive a round-trip drops from 58 to 10. The 10 that remain are all in `keyTone {0,15}` and `toneVolume {0,13}`, which hold more distinct values than Level's 1-10 scale can represent, so they can't round-trip no matter how the division is done. Widening Level's resolution would be a separate change.

I also added a guard for a zero-width source range, which divided by zero before.

Two sets of test expectations had to change, because they asserted the old behaviour:

- The four AnyTone `testMicGain()` cases expected `{{1,1}, {2,1}, {3,1}, {4,3}, ...}`, i.e. setting level 3 and getting 1 back. They now assert that every level the radio can represent maps to itself, which is the property that was actually broken.
- `D878UVTest::testAnalogMicGain()` used a fixture with `fmMicGain: 6` and expected 5 back. It now expects 6.

All 27 tests pass.
