### PR TITLE
D578UVCodeplug: enable encryption when channel has key

### DIFF
--- a/lib/d578uv_codeplug.cc
+++ b/lib/d578uv_codeplug.cc
@@ -150,6 +150,17 @@ D578UVCodeplug::ChannelElement::setEncryptionType(AdvancedEncryptionType type) {
 
 
 bool
+D578UVCodeplug::ChannelElement::digitalEncryptionEnabled() const {
+  return 0 != getUInt8(Offset::digitalEncryption());
+}
+
+void
+D578UVCodeplug::ChannelElement::enableDigitalEncryption(bool enable) {
+  setUInt8(Offset::digitalEncryption(), enable ? 0x01 : 0x00);
+}
+
+
+bool
 D578UVCodeplug::ChannelElement::analogScamblerEnabled() const {
   return FMScramblerFrequency::Off != (FMScramblerFrequency)getUInt8(Offset::fmScrambler());
 }
@@ -264,6 +275,7 @@ D578UVCodeplug::ChannelElement::fromChannelObj(const Channel *ch, Context &ctx) 
 
   // Apply extensions
   if (const FMChannel *fch = ch->as<FMChannel>()) {
+    enableDigitalEncryption(false);
     if (AnytoneFMChannelExtension *ext = fch->anytoneChannelExtension()) {
       // Common settings
       enableBluetooth(ext->handsFree());
@@ -278,6 +290,12 @@ D578UVCodeplug::ChannelElement::fromChannelObj(const Channel *ch, Context &ctx) 
       // Common settings
       enableBluetooth(ext->handsFree());
       // DMR specific extensions
+    }
+    // Enable digital encryption if a key is assigned to this channel
+    if (CommercialChannelExtension *ext = dch->commercialExtension()) {
+      enableDigitalEncryption(nullptr != ext->encryptionKey());
+    } else {
+      enableDigitalEncryption(false);
     }
   }
 

--- a/lib/d578uv_codeplug.hh
+++ b/lib/d578uv_codeplug.hh
@@ -114,6 +114,11 @@ public:
     AdvancedEncryptionType advancedEncryptionType() const override;
     void setEncryptionType(AdvancedEncryptionType type) override;
 
+    /** Returns @c true if digital encryption is enabled for this channel. */
+    virtual bool digitalEncryptionEnabled() const;
+    /** Enables/disables digital encryption for this channel. */
+    virtual void enableDigitalEncryption(bool enable);
+
     /** Returns @c true if the analog scambler is enabled. */
     virtual bool analogScamblerEnabled() const;
     /** If enabled, returns the analog scrambler frequency. */
@@ -145,6 +150,7 @@ public:
       static constexpr Bit roaming()                       { return {0x0034, 6}; }
       static constexpr unsigned int fmScrambler()          { return 0x003a; }
       static constexpr unsigned int customScrambler()      { return 0x003b; }
+      static constexpr unsigned int digitalEncryption()    { return 0x003c; }
       static constexpr Bit multipleKeyEncryption()         { return {0x003d, 0}; }
       static constexpr Bit randomKey()                     { return {0x003d, 1}; }
       static constexpr Bit sms()                           { return {0x003d, 2}; }

--- a/test/d578uv_test.cc
+++ b/test/d578uv_test.cc
@@ -257,6 +257,71 @@ D578UVTest::testARC4Encryption() {
            decoded.commercialExtension()->encryptionKeys()->key(0));
 }
 
+void
+D578UVTest::testAESEncryption() {
+  ErrorStack err;
+
+  // Load config from file
+  Config config;
+  if (! config.readYAML(":/data/aes_encryption.yaml", err)) {
+    QFAIL(QString("Cannot open codeplug file:\n%1")
+          .arg(err.format(" ")).toStdString().c_str());
+  }
+
+  D578UVCodeplug codeplug;
+  Codeplug::Flags flags; flags.setUpdateCodeplug(false);
+  if (! codeplug.encode(&config, flags, err)) {
+    QFAIL(QString("Cannot encode codeplug for AnyTone AT-D878UV: %1")
+          .arg(err.format()).toStdString().c_str());
+  }
+
+  // Verify the digital encryption enable byte is set in the encoded channel element
+  D578UVCodeplug::ChannelElement ch(codeplug.data(0x00800000));
+  QVERIFY(ch.digitalEncryptionEnabled());
+
+  Config decoded;
+  if (! codeplug.decode(&decoded, err)) {
+    QFAIL(QString("Cannot decode codeplug for AnyTone AT-D878UV: %1")
+          .arg(err.format()).toStdString().c_str());
+  }
+
+  // Verify existence of key
+  QVERIFY(nullptr != decoded.commercialExtension());
+  QCOMPARE(decoded.commercialExtension()->encryptionKeys()->count(), 1);
+  QCOMPARE(decoded.commercialExtension()->encryptionKeys()->key(0)->key(), QByteArray::fromHex("11223344556677889900AABBCCDDEEFF"));
+
+  // Verify link to channel
+  QVERIFY(nullptr != decoded.channelList()->channel(0)->as<DMRChannel>()->commercialExtension());
+  QCOMPARE(decoded.channelList()->channel(0)->as<DMRChannel>()->commercialExtension()->encryptionKey(),
+           decoded.commercialExtension()->encryptionKeys()->key(0));
+}
+
+void
+D578UVTest::testAESEncryptionWithoutKeyDoesNotEnableEncryption() {
+  ErrorStack err;
+
+  // Load config from file. This config has an AES key assigned to the channel
+  Config config;
+  if (! config.readYAML(":/data/aes_encryption.yaml", err)) {
+    QFAIL(QString("Cannot open codeplug file:\n%1")
+          .arg(err.format(" ")).toStdString().c_str());
+  }
+
+  // Remove the encryption key from the channel
+  auto *dch = config.channelList()->channel(0)->as<DMRChannel>();
+  dch->commercialExtension()->setEncryptionKey(nullptr);
+
+  D578UVCodeplug codeplug;
+  Codeplug::Flags flags; flags.setUpdateCodeplug(false);
+  if (! codeplug.encode(&config, flags, err)) {
+    QFAIL(QString("Cannot encode codeplug for AnyTone AT-D878UV: %1")
+          .arg(err.format()).toStdString().c_str());
+  }
+
+  // Verify the digital encryption enable byte is NOT set in the encoded channel element
+  D578UVCodeplug::ChannelElement noKeyCh(codeplug.data(0x00800000));
+  QVERIFY(! noKeyCh.digitalEncryptionEnabled());
+}
 
 void
 D578UVTest::testAMChannel() {
@@ -281,4 +346,3 @@ D578UVTest::testAMChannel() {
 
 
 QTEST_GUILESS_MAIN(D578UVTest)
-

--- a/test/d578uv_test.hh
+++ b/test/d578uv_test.hh
@@ -16,6 +16,8 @@ private slots:
   void testBasicConfigDecoding();
   void testChannelFrequency();
   void testARC4Encryption();
+  void testAESEncryption();
+  void testAESEncryptionWithoutKeyDoesNotEnableEncryption();
   void testAMChannel();
   void testMicGain(); // Retression test for #773
   void testChannelDataACK(); // Regression test for #813


### PR DESCRIPTION
When qdmr adds an encryption key to a channel on the D578UVIII, it doesn't actually enable encryption. One must go into the channel menu and manually select the key. That lasts until you need to write from qdmr again, and then encryption is disabled again and one must manually select the key again.

By comparing the binary codeplug after making the required menu changes, I found that, at least on this radio, offset `0x003c` has a `0x01` in it when encryption is properly enabled, and otherwise is `0x00`. This PR fixes #1000 by duplicating this pattern in qdmr, thereby successfully enabling encryption when a key is assigned to a channel.