### PR TITLE
Add DM32UV programmable button settings

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -47,7 +47,7 @@ qt_add_library(libdmrconf SHARED
   dmr6x2uv2.cc dmr6x2uv2_codeplug.cc dmr6x2uv2_limits.cc
   auctus_a6_interface.cc
   dr1801uv.cc dr1801uv_interface.cc dr1801uv_codeplug.cc dr1801uv_filereader.cc dr1801uv_limits.cc
-  dm32uv.cc dm32uv_interface.cc dm32uv_limits.cc dm32uv_codeplug.cc dm32uv_callsigndb.cc
+  dm32uv.cc dm32uv_interface.cc dm32uv_limits.cc dm32uv_codeplug.cc dm32uv_callsigndb.cc dm32uv_extensions.cc
         task_progress.cc
         task_progress.hh)
 
@@ -70,7 +70,7 @@ target_sources(libdmrconf PUBLIC FILE_SET HEADERS
   md390.hh md390_codeplug.hh md390_filereader.hh md390_limits.hh
   uv390.hh uv390_codeplug.hh uv390_callsigndb.hh uv390_filereader.hh uv390_limits.hh
   dm1701.hh dm1701_codeplug.hh dm1701_callsigndb.hh dm1701_filereader.hh dm1701_limits.hh
-  radioddity_radio.hh radioddity_codeplug.hh radioddity_extensions.hh radioddity_interface.hh
+  radioddity_radio.hh radioddity_codeplug.hh radioddity_extensions.hh radioddity_interface.hh dm32uv_extensions.hh
   rd5r.hh rd5r_codeplug.hh rd5r_filereader.hh rd5r_limits.hh
   gd77.hh gd77_codeplug.hh gd77_callsigndb.hh gd77_filereader.hh gd77_limits.hh
   opengd77_interface.hh opengd77base.hh opengd77base_codeplug.hh opengd77base_callsigndb.hh

--- a/lib/dm32uv_codeplug.cc
+++ b/lib/dm32uv_codeplug.cc
@@ -3399,6 +3399,20 @@ DM32UVCodeplug::GeneralSettingsElement::decode(Context &ctx, const ErrorStack &e
   ctx.config()->settings()->dmr()->setTalkerAliasEncoding(talkerAliasEncoding());
   ctx.config()->settings()->dmr()->setPreamble(dmrPreambleDuration());
 
+  if (!ctx.config()->settings()->dm32uvExtension())
+    ctx.config()->settings()->setDM32UVExtension(new DM32UVSettingsExtension());
+  auto *buttons = ctx.config()->settings()->dm32uvExtension()->buttons();
+  buttons->setLongPressDuration(longPressDuration());
+  buttons->setSK1Short(static_cast<DM32UVButtonSettingsExtension::Function>(sk1Short()));
+  buttons->setSK1Long(static_cast<DM32UVButtonSettingsExtension::Function>(sk1Long()));
+  buttons->setSK2Short(static_cast<DM32UVButtonSettingsExtension::Function>(sk2Short()));
+  buttons->setSK2Long(static_cast<DM32UVButtonSettingsExtension::Function>(sk2Long()));
+  buttons->setP1Short(static_cast<DM32UVButtonSettingsExtension::Function>(p1Short()));
+  buttons->setP1Long(static_cast<DM32UVButtonSettingsExtension::Function>(p1Long()));
+  buttons->setP2Short(static_cast<DM32UVButtonSettingsExtension::Function>(p2Short()));
+  buttons->setP2Long(static_cast<DM32UVButtonSettingsExtension::Function>(p2Long()));
+  buttons->enableSideKeyLock(sideKeyLockEnabled());
+
   return true;
 }
 
@@ -3453,6 +3467,20 @@ DM32UVCodeplug::GeneralSettingsElement::encode(Context &ctx, const ErrorStack &e
   enableTXTalkerAlias(ctx.config()->settings()->dmr()->sendTalkerAliasEnabled());
   setTalkerAliasEncoding(ctx.config()->settings()->dmr()->talkerAliasEncoding());
   setDmrPreambleDuration(ctx.config()->settings()->dmr()->preamble());
+
+  if (auto *extension = ctx.config()->settings()->dm32uvExtension()) {
+    auto *buttons = extension->buttons();
+    setLongPressDuration(buttons->longPressDuration());
+    setSK1Short(static_cast<KeyFunction::Function>(buttons->sk1Short()));
+    setSK1Long(static_cast<KeyFunction::Function>(buttons->sk1Long()));
+    setSK2Short(static_cast<KeyFunction::Function>(buttons->sk2Short()));
+    setSK2Long(static_cast<KeyFunction::Function>(buttons->sk2Long()));
+    setP1Short(static_cast<KeyFunction::Function>(buttons->p1Short()));
+    setP1Long(static_cast<KeyFunction::Function>(buttons->p1Long()));
+    setP2Short(static_cast<KeyFunction::Function>(buttons->p2Short()));
+    setP2Long(static_cast<KeyFunction::Function>(buttons->p2Long()));
+    enableSideKeyLock(buttons->sideKeyLock());
+  }
 
   return true;
 }

--- a/lib/dm32uv_extensions.cc
+++ b/lib/dm32uv_extensions.cc
@@ -1,0 +1,66 @@
+#include "dm32uv_extensions.hh"
+
+
+DM32UVButtonSettingsExtension::DM32UVButtonSettingsExtension(QObject *parent)
+  : ConfigItem(parent), _longPressDuration(Interval::fromSeconds(1)),
+    _sk1Short(Function::None), _sk1Long(Function::None),
+    _sk2Short(Function::None), _sk2Long(Function::None),
+    _p1Short(Function::None), _p1Long(Function::None),
+    _p2Short(Function::None), _p2Long(Function::None),
+    _sideKeyLock(false)
+{
+}
+
+ConfigItem *
+DM32UVButtonSettingsExtension::clone() const {
+  auto *copy = new DM32UVButtonSettingsExtension();
+  if (!copy->copy(*this)) {
+    delete copy;
+    return nullptr;
+  }
+  return copy;
+}
+
+#define DM32UV_BUTTON_ACCESSORS(name, setter, type) \
+  type DM32UVButtonSettingsExtension::name() const { return _##name; } \
+  void DM32UVButtonSettingsExtension::setter(type value) { \
+    if (_##name == value) return; \
+    _##name = value; \
+    emit modified(this); \
+  }
+
+DM32UV_BUTTON_ACCESSORS(longPressDuration, setLongPressDuration, Interval)
+DM32UV_BUTTON_ACCESSORS(sk1Short, setSK1Short, DM32UVButtonSettingsExtension::Function)
+DM32UV_BUTTON_ACCESSORS(sk1Long, setSK1Long, DM32UVButtonSettingsExtension::Function)
+DM32UV_BUTTON_ACCESSORS(sk2Short, setSK2Short, DM32UVButtonSettingsExtension::Function)
+DM32UV_BUTTON_ACCESSORS(sk2Long, setSK2Long, DM32UVButtonSettingsExtension::Function)
+DM32UV_BUTTON_ACCESSORS(p1Short, setP1Short, DM32UVButtonSettingsExtension::Function)
+DM32UV_BUTTON_ACCESSORS(p1Long, setP1Long, DM32UVButtonSettingsExtension::Function)
+DM32UV_BUTTON_ACCESSORS(p2Short, setP2Short, DM32UVButtonSettingsExtension::Function)
+DM32UV_BUTTON_ACCESSORS(p2Long, setP2Long, DM32UVButtonSettingsExtension::Function)
+DM32UV_BUTTON_ACCESSORS(sideKeyLock, enableSideKeyLock, bool)
+
+#undef DM32UV_BUTTON_ACCESSORS
+
+
+DM32UVSettingsExtension::DM32UVSettingsExtension(QObject *parent)
+  : ConfigExtension(parent), _buttons(new DM32UVButtonSettingsExtension(this))
+{
+  connect(_buttons, &DM32UVButtonSettingsExtension::modified,
+          this, &DM32UVSettingsExtension::modified);
+}
+
+ConfigItem *
+DM32UVSettingsExtension::clone() const {
+  auto *copy = new DM32UVSettingsExtension();
+  if (!copy->copy(*this)) {
+    delete copy;
+    return nullptr;
+  }
+  return copy;
+}
+
+DM32UVButtonSettingsExtension *
+DM32UVSettingsExtension::buttons() const {
+  return _buttons;
+}

--- a/lib/dm32uv_extensions.hh
+++ b/lib/dm32uv_extensions.hh
@@ -1,0 +1,87 @@
+#ifndef DM32UVEXTENSIONS_HH
+#define DM32UVEXTENSIONS_HH
+
+#include "configobject.hh"
+#include "interval.hh"
+
+
+/** Represents the programmable button settings of the Baofeng DM-32UV. */
+class DM32UVButtonSettingsExtension: public ConfigItem
+{
+  Q_OBJECT
+
+  Q_PROPERTY(Interval longPressDuration READ longPressDuration WRITE setLongPressDuration)
+  Q_PROPERTY(Function sk1Short READ sk1Short WRITE setSK1Short)
+  Q_PROPERTY(Function sk1Long READ sk1Long WRITE setSK1Long)
+  Q_PROPERTY(Function sk2Short READ sk2Short WRITE setSK2Short)
+  Q_PROPERTY(Function sk2Long READ sk2Long WRITE setSK2Long)
+  Q_PROPERTY(Function p1Short READ p1Short WRITE setP1Short)
+  Q_PROPERTY(Function p1Long READ p1Long WRITE setP1Long)
+  Q_PROPERTY(Function p2Short READ p2Short WRITE setP2Short)
+  Q_PROPERTY(Function p2Long READ p2Long WRITE setP2Long)
+  Q_PROPERTY(bool sideKeyLock READ sideKeyLock WRITE enableSideKeyLock)
+
+public:
+  enum class Function {
+    None = 0, PowerSelect = 1, Volt = 2, Talkaround = 3,
+    DMREncryption = 4, VOX = 6, ChannelMode = 7, Alarm = 8,
+    OneTouch1 = 9, OneTouch2 = 10, OneTouch3 = 11, OneTouch4 = 12,
+    OneTouch5 = 13, SMS = 14, Contacts = 15, ZoneUp = 16, ZoneDown = 17,
+    Scan = 18, ToggleRecord = 19, PreviousRecord = 20, NextRecord = 21,
+    FMBCRadio = 22, FMBCScan = 23, GPSInformation = 24, Monitor = 25,
+    ToggleMainChannel = 26, LoneWorker = 27, KeypadLock = 28, Mute = 29,
+    TBST = 30, APRSTX = 31, ChannelType = 32, DisplayMode = 33,
+    CTCSSDSCScan = 34, CTCSSDSCSettings = 25, SilentTone = 36,
+    Roaming = 37, SubPTT = 38,
+    OneKeyScanFrequency = 40, Flashlight = 41
+  };
+  Q_ENUM(Function)
+
+  explicit DM32UVButtonSettingsExtension(QObject *parent=nullptr);
+  ConfigItem *clone() const;
+
+  Interval longPressDuration() const;
+  void setLongPressDuration(Interval duration);
+  Function sk1Short() const;
+  void setSK1Short(Function function);
+  Function sk1Long() const;
+  void setSK1Long(Function function);
+  Function sk2Short() const;
+  void setSK2Short(Function function);
+  Function sk2Long() const;
+  void setSK2Long(Function function);
+  Function p1Short() const;
+  void setP1Short(Function function);
+  Function p1Long() const;
+  void setP1Long(Function function);
+  Function p2Short() const;
+  void setP2Short(Function function);
+  Function p2Long() const;
+  void setP2Long(Function function);
+  bool sideKeyLock() const;
+  void enableSideKeyLock(bool enable);
+
+protected:
+  Interval _longPressDuration;
+  Function _sk1Short, _sk1Long, _sk2Short, _sk2Long;
+  Function _p1Short, _p1Long, _p2Short, _p2Long;
+  bool _sideKeyLock;
+};
+
+
+/** Device-specific settings for the Baofeng DM-32UV. */
+class DM32UVSettingsExtension: public ConfigExtension
+{
+  Q_OBJECT
+  Q_PROPERTY(DM32UVButtonSettingsExtension *buttons READ buttons)
+
+public:
+  Q_INVOKABLE explicit DM32UVSettingsExtension(QObject *parent=nullptr);
+  ConfigItem *clone() const;
+  DM32UVButtonSettingsExtension *buttons() const;
+
+protected:
+  DM32UVButtonSettingsExtension *_buttons;
+};
+
+#endif // DM32UVEXTENSIONS_HH

--- a/lib/radiosettings.cc
+++ b/lib/radiosettings.cc
@@ -11,7 +11,7 @@ RadioSettings::RadioSettings(QObject *parent)
     _tone(new ToneSettings(this)),
     _gnss(new GNSSSettings(this)), _dmr(new DMRSettings(this)),
     _tytExtension(nullptr), _radioddityExtension(nullptr),
-    _anytoneExtension(nullptr)
+    _anytoneExtension(nullptr), _dm32uvExtension(nullptr)
 {
   connect(_boot, &BootSettings::modified, this, &RadioSettings::modified);
   connect(_audio, &AudioSettings::modified, this, &RadioSettings::modified);
@@ -52,6 +52,7 @@ RadioSettings::clear() {
   setTyTExtension(nullptr);
   setRadioddityExtension(nullptr);
   setAnytoneExtension(nullptr);
+  setDM32UVExtension(nullptr);
 }
 
 Channel::Power
@@ -184,6 +185,26 @@ RadioSettings::setAnytoneExtension(AnytoneSettingsExtension *ext) {
   if (_anytoneExtension) {
     _anytoneExtension->setParent(this);
     connect(_anytoneExtension, SIGNAL(modified(ConfigItem*)), this, SLOT(onExtensionModified()));
+  }
+  emit modified(this);
+}
+
+
+DM32UVSettingsExtension *
+RadioSettings::dm32uvExtension() const {
+  return _dm32uvExtension;
+}
+
+void
+RadioSettings::setDM32UVExtension(DM32UVSettingsExtension *ext) {
+  if (_dm32uvExtension) {
+    disconnect(_dm32uvExtension, SIGNAL(modified(ConfigItem*)), this, SLOT(onExtensionModified()));
+    _dm32uvExtension->deleteLater();
+  }
+  _dm32uvExtension = ext;
+  if (_dm32uvExtension) {
+    _dm32uvExtension->setParent(this);
+    connect(_dm32uvExtension, SIGNAL(modified(ConfigItem*)), this, SLOT(onExtensionModified()));
   }
   emit modified(this);
 }

--- a/lib/radiosettings.hh
+++ b/lib/radiosettings.hh
@@ -12,6 +12,7 @@
 #include "radioddity_extensions.hh"
 #include "anytone_settingsextension.hh"
 #include "tyt_extensions.hh"
+#include "dm32uv_extensions.hh"
 
 
 /** Represents the common radio-global settings.
@@ -41,6 +42,8 @@ class RadioSettings : public ConfigItem
   Q_PROPERTY(RadiodditySettingsExtension * radioddity READ radioddityExtension WRITE setRadioddityExtension)
   /** Settings for AnyTone devices. */
   Q_PROPERTY(AnytoneSettingsExtension *anytone READ anytoneExtension WRITE setAnytoneExtension)
+  /** Settings for Baofeng DM-32UV devices. */
+  Q_PROPERTY(DM32UVSettingsExtension *dm32uv READ dm32uvExtension WRITE setDM32UVExtension)
 
 public:
   /** Default constructor. */
@@ -99,6 +102,11 @@ public:
   /** Sets the AnyTone device specific radio settings. */
   void setAnytoneExtension(AnytoneSettingsExtension *ext);
 
+  /** Returns the Baofeng DM-32UV device-specific settings. */
+  DM32UVSettingsExtension *dm32uvExtension() const;
+  /** Sets the Baofeng DM-32UV device-specific settings. */
+  void setDM32UVExtension(DM32UVSettingsExtension *ext);
+
   bool parse(const YAML::Node &node, Context &ctx, const ErrorStack &err=ErrorStack());
 
 protected:
@@ -131,6 +139,8 @@ protected:
   RadiodditySettingsExtension *_radioddityExtension;
   /** Device specific settings extension for AnyTone devices. */
   AnytoneSettingsExtension *_anytoneExtension;
+  /** Device specific settings extension for Baofeng DM-32UV devices. */
+  DM32UVSettingsExtension *_dm32uvExtension;
 };
 
 #endif // RADIOCONFIG_HH

--- a/test/dm32uv_test.cc
+++ b/test/dm32uv_test.cc
@@ -119,6 +119,47 @@ DM32UVTest::testAMChannelReencoding() {
 
 
 void
+DM32UVTest::testButtonSettingsReencoding() {
+  ErrorStack err;
+  Config config;
+  QVERIFY2(config.readYAML(":/data/config_test.yaml", err),
+           qPrintable(err.format()));
+  auto *extension = new DM32UVSettingsExtension();
+  config.settings()->setDM32UVExtension(extension);
+  auto *buttons = extension->buttons();
+  buttons->setLongPressDuration(Interval::fromSeconds(3));
+  buttons->setSK1Short(DM32UVButtonSettingsExtension::Function::Monitor);
+  buttons->setSK1Long(DM32UVButtonSettingsExtension::Function::ZoneUp);
+  buttons->setSK2Short(DM32UVButtonSettingsExtension::Function::Scan);
+  buttons->setSK2Long(DM32UVButtonSettingsExtension::Function::ZoneDown);
+  buttons->setP1Short(DM32UVButtonSettingsExtension::Function::PowerSelect);
+  buttons->setP1Long(DM32UVButtonSettingsExtension::Function::ChannelType);
+  buttons->setP2Short(DM32UVButtonSettingsExtension::Function::VOX);
+  buttons->setP2Long(DM32UVButtonSettingsExtension::Function::Flashlight);
+  buttons->enableSideKeyLock(true);
+
+  DM32UVCodeplug codeplug;
+  QVERIFY2(codeplug.encode(&config, Codeplug::Flags(), err),
+           qPrintable(err.format()));
+
+  Config decoded;
+  QVERIFY2(codeplug.decode(&decoded, err), qPrintable(err.format()));
+  QVERIFY(decoded.settings()->dm32uvExtension());
+  auto *decodedButtons = decoded.settings()->dm32uvExtension()->buttons();
+  QCOMPARE(decodedButtons->longPressDuration(), Interval::fromSeconds(3));
+  QCOMPARE(decodedButtons->sk1Short(), DM32UVButtonSettingsExtension::Function::Monitor);
+  QCOMPARE(decodedButtons->sk1Long(), DM32UVButtonSettingsExtension::Function::ZoneUp);
+  QCOMPARE(decodedButtons->sk2Short(), DM32UVButtonSettingsExtension::Function::Scan);
+  QCOMPARE(decodedButtons->sk2Long(), DM32UVButtonSettingsExtension::Function::ZoneDown);
+  QCOMPARE(decodedButtons->p1Short(), DM32UVButtonSettingsExtension::Function::PowerSelect);
+  QCOMPARE(decodedButtons->p1Long(), DM32UVButtonSettingsExtension::Function::ChannelType);
+  QCOMPARE(decodedButtons->p2Short(), DM32UVButtonSettingsExtension::Function::VOX);
+  QCOMPARE(decodedButtons->p2Long(), DM32UVButtonSettingsExtension::Function::Flashlight);
+  QVERIFY(decodedButtons->sideKeyLock());
+}
+
+
+void
 DM32UVTest::testChannelBankEncoding() {
   static const uint32_t bank0=0x12000, bank1 = 0x13000, bank2 = 0x14000;
   Config config;

--- a/test/dm32uv_test.hh
+++ b/test/dm32uv_test.hh
@@ -17,6 +17,7 @@ private slots:
   void testBasicConfigReencoding();
   void testProstProcessingOfEmptyCodeplug();
   void testAMChannelReencoding();
+  void testButtonSettingsReencoding();
   /** Regression test for #873 */
   void testChannelBankEncoding();
   /** Regression test fo #967 */


### PR DESCRIPTION
## Summary

Add YAML-configurable programmable button settings for the Baofeng DM-32UV. The codeplug implementation already had byte-level accessors for these fields, but they were not exposed through qdmr's configuration model.

## Supported settings

```yaml
settings:
  dm32uv:
    buttons:
      longPressDuration: 1 s
      sk1Short: Monitor
      sk1Long: ZoneUp
      sk2Short: Scan
      sk2Long: ZoneDown
      p1Short: PowerSelect
      p1Long: ChannelType
      p2Short: VOX
      p2Long: Flashlight
      sideKeyLock: false
```

The button actions use the DM-32UV function enum, including the existing function codes and aliases.

## Changes

- Add `DM32UVSettingsExtension` and nested button settings.
- Register the extension on `RadioSettings`.
- Wire button settings through `DM32UVCodeplug::GeneralSettingsElement`.
- Add encode/decode regression coverage.

## Validation

- Full qdmr build succeeds.
- Full qdmr test suite passes: `27/27`.
- YAML verify, encode, and decode round-trip preserves all button settings.
- Hardware-tested on a Baofeng DM-32UV: the candidate was written, read back after a power cycle, and the physical SK1/SK2/P1/P2 button behavior matched the configured mappings.

## Scope

This change is limited to button settings. Display colors and other DM-32UV-specific settings remain separate follow-up work.